### PR TITLE
patch: Create release tag with git instead of gh

### DIFF
--- a/.github/workflows/__release.yaml
+++ b/.github/workflows/__release.yaml
@@ -27,7 +27,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create release
-        run: gh release create ${{ steps.get-version.outputs.full_version }} --generate-notes
+        run: |
+          git tag ${{ steps.get-version.outputs.full_version }}
+          gh release create ${{ steps.get-version.outputs.full_version }} --verify-tag --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update major version tag


### PR DESCRIPTION
Scenario:
commit A and commit B are pushed to main
Workflow for commit A runs after commit B is pushed
`gh release create` will create a release that includes commit B

This change ensures that when the workflow runs on commit A the release does not include commit B