### PR TITLE
patch(build_charms_with_cache.yaml): Force charmcraft to update all files

### DIFF
--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -124,7 +124,7 @@ jobs:
             # Why this is needed:
             #   It is possible that a cache is created on the main branch after a file is modified on a PR branch.
             #   Without this, if the cache from main were used, that file would not be updated in the build.
-            sudo touch --date="1970-01-01" /var/snap/lxd/common/lxd/containers/$container_name_with_inode/rootfs/root/parts/charm/state/pull
+            sudo touch --date="1970-01-01" /var/snap/lxd/common/lxd/containers/charmcraft_$container_name_with_inode/rootfs/root/parts/charm/state/pull
           done
       - name: Pack charm
         id: pack


### PR DESCRIPTION
Potentially fixes #14 

Force charmcraft to update all files in PULL step

By default, charmcraft only updates files that were modified after the last build.
Source: https://github.com/canonical/craft-parts/blob/82038513adc861e30dc91783b573c86b87e58873/craft_parts/sources/local_source.py#L99-L123

Why this is needed:
It is possible that a cache is created on the main branch after a file is modified on a PR branch.
Without this, if the cache from main were used, that file would not be updated in the build.