### PR TITLE
patch(build_charms_with_cache.yaml): Remove `actions.yaml` from cache key

### DIFF
--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ~/ga-charmcraft-cache/**
-          key: charmcraft-pack-${{ matrix.charm.directory_path }}-${{ matrix.charm.bases_index }}-${{ steps.charmcraft-version.outputs.version }}-${{ hashFiles(format('{0}/charmcraft.yaml', matrix.charm.directory_path), format('{0}/actions.yaml', matrix.charm.directory_path), format('{0}/requirements.txt', matrix.charm.directory_path)) }}
+          key: charmcraft-pack-${{ matrix.charm.directory_path }}-${{ matrix.charm.bases_index }}-${{ steps.charmcraft-version.outputs.version }}-${{ hashFiles(format('{0}/charmcraft.yaml', matrix.charm.directory_path), format('{0}/requirements.txt', matrix.charm.directory_path)) }}
       - name: Import cached container
         if: ${{ steps.restore-cache.outputs.cache-hit }}
         run: |


### PR DESCRIPTION
The cached LXC container does not need to be recreated when `actions.yaml` changes

Related discussion: https://chat.canonical.com/canonical/pl/3i1rukxuht8kbp4ax7xnh1d7pw