### PR TITLE
patch(release_charm.yaml): Use `removeprefix()` instead of `lstrip()`

### DIFF
--- a/release_charm.py
+++ b/release_charm.py
@@ -63,7 +63,7 @@ for resource_name, resource in resources.items():
     logging.info(f"Downloading OCI image: {image_name}")
     run(["docker", "pull", image_name])
     image_id = run(["docker", "image", "inspect", image_name, "--format", "'{{.Id}}'"])
-    image_id = image_id.rstrip("\n").strip("'").lstrip("sha256:")
+    image_id = image_id.rstrip("\n").strip("'").removeprefix("sha256:")
     assert "\n" not in image_id, f"Multiple local images found for {image_name}"
     logging.info(f"Uploading charm resource: {resource_name}")
     output = run(


### PR DESCRIPTION
.lstrip removes all characters from the argument string without looking at order

Failed release: https://github.com/canonical/mysql-k8s-operator/actions/runs/4628426136/jobs/8189111937

Release failed since `sha256:65749c3ab318a6b2e3c8a8a6f731d15acaecf25669917181f5d24e01ce0cae95` was converted to `749c3ab318a6b2e3c8a8a6f731d15acaecf25669917181f5d24e01ce0cae95` instead of `65749c3ab318a6b2e3c8a8a6f731d15acaecf25669917181f5d24e01ce0cae95`