### PR TITLE
feat: expose ubuntu-version in build_charms_with_cache.yaml

### DIFF
--- a/.github/workflows/build_charms_with_cache.md
+++ b/.github/workflows/build_charms_with_cache.md
@@ -1,4 +1,14 @@
 Workflow file: [build_charms_with_cache.yaml](build_charms_with_cache.yaml)
 
 ## Usage
+```yaml
+jobs:
+ build:
+    name: Build charms
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@<version>
+    with:
+      # Ubuntu version that will be used for running this job
+      # It is used as value for "runs-on"
+      ubuntu-version: ubuntu-20.04 
+```
 See https://discourse.charmhub.io/t/faster-integration-tests-with-github-caching/8782

--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -10,6 +10,10 @@ on:
         description: Charm packages are uploaded to this GitHub artifact name
         default: charms-packed-with-cache
         type: string
+      ubuntu-version:
+        description: Ubuntu version to be used by the GitHub runners
+        default: ubuntu-latest
+        type: string
     outputs:
       artifact-name:
         description: Charm packages are uploaded to this GitHub artifact name
@@ -48,7 +52,7 @@ jobs:
     name: Collect charms
     needs:
       - get-workflow-version
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.ubuntu-version }}
     timeout-minutes: 5
     steps:
       - name: Install pyyaml
@@ -77,7 +81,7 @@ jobs:
     name: ${{ matrix.charm._job_display_name }}
     needs:
       - collect-charms
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.ubuntu-version }}
     timeout-minutes: 60
     steps:
       - name: Checkout


### PR DESCRIPTION
Expose `ubuntu-version` as an input for running the workflow on a specific ubuntu version. This parameter is used in the runs-on field, and can be configured by other workflows.