### PR TITLE
patch(build_charms_with_cache.yaml): Remove `local:` from charm file path

### DIFF
--- a/collect_charms.py
+++ b/collect_charms.py
@@ -44,7 +44,7 @@ for charmcraft_yaml in Path(".").glob("**/charmcraft.yaml"):
                 "_job_display_name": f"Build {charm_name} charm | {version}",
                 "bases_index": index,
                 "directory_path": path.as_posix(),
-                "file_path": f"local:./{path/charm_name}_ubuntu-{version}-amd64.charm",
+                "file_path": f"./{path/charm_name}_ubuntu-{version}-amd64.charm",
             }
         )
 logging.info(f"Collected {charms=}")


### PR DESCRIPTION
python-libjuju (called in `ops_test.model.deploy()`) will automatically add the `local:` prefix if it is not present and the path begins with `.`
https://github.com/juju/python-libjuju/blob/c7d0a1049125e41c70987896b0ffd3463675ca75/juju/model.py#L1713-L1714

Makes it easier to override ops_test.build_charm in a way that's compatible with the original method