### PR TITLE
patch: Use single quotes for GitHub expressions in bash instead of double quotes

### DIFF
--- a/.github/workflows/__lint.yaml
+++ b/.github/workflows/__lint.yaml
@@ -21,4 +21,4 @@ jobs:
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
       - name: Run actionlint
         run: |
-          "${{ steps.install.outputs.executable }}" -color
+          '${{ steps.install.outputs.executable }}' -color

--- a/.github/workflows/__release.yaml
+++ b/.github/workflows/__release.yaml
@@ -29,13 +29,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update major version tag
         run: |
-          git tag "${{ steps.get-version.outputs.major_version }}" --force
-          git push origin "${{ steps.get-version.outputs.major_version }}" --force
+          git tag '${{ steps.get-version.outputs.major_version }}' --force
+          git push origin '${{ steps.get-version.outputs.major_version }}' --force
       - name: Create release
         run: |
-          git tag "${{ steps.get-version.outputs.full_version }}"
-          git push origin "${{ steps.get-version.outputs.full_version }}"
-          gh release create "${{ steps.get-version.outputs.full_version }}" --verify-tag --generate-notes
+          git tag '${{ steps.get-version.outputs.full_version }}'
+          git push origin '${{ steps.get-version.outputs.full_version }}'
+          gh release create '${{ steps.get-version.outputs.full_version }}' --verify-tag --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -110,7 +110,7 @@ jobs:
           # Project setup copied from https://github.com/canonical/craft-providers/blob/20d154bb8fa9868a678c5621f124a02e2b9e72ad/craft_providers/lxd/project.py#L26
           lxc project create charmcraft
           lxc --project default profile show default | lxc --project charmcraft profile edit default
-          charm_repository_directory_inode=$(stat --format "%i" "${{ matrix.charm.directory_path }}")
+          charm_repository_directory_inode=$(stat --format "%i" '${{ matrix.charm.directory_path }}')
           for container_tarball in ~/ga-charmcraft-cache/*
           do
             lxc --project charmcraft import "$container_tarball"
@@ -135,7 +135,7 @@ jobs:
       - name: Pack charm
         id: pack
         working-directory: ${{ matrix.charm.directory_path }}
-        run: charmcraft pack --bases-index="${{ matrix.charm.bases_index }}"
+        run: charmcraft pack --bases-index='${{ matrix.charm.bases_index }}'
       - name: Upload charmcraft logs
         if: ${{ failure() && steps.pack.outcome == 'failure' }}
         uses: actions/upload-artifact@v3
@@ -159,7 +159,7 @@ jobs:
         if: ${{ !steps.restore-cache.outputs.cache-hit || github.event_name == 'schedule' }}
         run: |
           mkdir -p ~/ga-charmcraft-cache
-          charm_repository_directory_inode=$(stat --format "%i" "${{ matrix.charm.directory_path }}")
+          charm_repository_directory_inode=$(stat --format "%i" '${{ matrix.charm.directory_path }}')
           for container_name_with_inode in $(lxc --project charmcraft list --columns n --format csv)
           do
             # charmcraft 2.3.0 added a "base instance" LXC container that is not specific to a charm (and doesn't contain an inode)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
       - name: Run actionlint
         run: |
-          "${{ steps.install.outputs.executable }}" -color
+          '${{ steps.install.outputs.executable }}' -color
 
   tox-lint:
     name: tox run -e lint

--- a/.github/workflows/release_charm.yaml
+++ b/.github/workflows/release_charm.yaml
@@ -73,16 +73,16 @@ jobs:
       - name: Upload & release charm
         id: release
         working-directory: caller-repo
-        run: python3 ../workflow-repo/release_charm.py --charm-directory "${{ inputs.path-to-charm-directory }}" --channel "${{ inputs.channel }}"
+        run: python3 ../workflow-repo/release_charm.py --charm-directory '${{ inputs.path-to-charm-directory }}' --channel '${{ inputs.channel }}'
         env:
           CHARMCRAFT_AUTH: ${{ secrets.charmhub-token }}
       - name: Create GitHub release
         if: ${{ inputs.create-github-release }}
         working-directory: caller-repo
         run: |
-          git tag "${{ steps.release.outputs.release_tag }}"
-          git push origin "${{ steps.release.outputs.release_tag }}"
-          gh release create "${{ steps.release.outputs.release_tag }}" --verify-tag --generate-notes --title "${{ steps.release.outputs.release_title }}" --notes-file release_notes.txt
+          git tag '${{ steps.release.outputs.release_tag }}'
+          git push origin '${{ steps.release.outputs.release_tag }}'
+          gh release create '${{ steps.release.outputs.release_tag }}' --verify-tag --generate-notes --title '${{ steps.release.outputs.release_title }}' --notes-file release_notes.txt
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload charmcraft logs

--- a/.github/workflows/sync_issue_to_jira.yaml
+++ b/.github/workflows/sync_issue_to_jira.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Determine Jira issue type
         id: issue-type
         run: |
-          if "${{ contains(github.event.issue.labels.*.name, 'bug') }}"
+          if '${{ contains(github.event.issue.labels.*.name, 'bug') }}'
           then
             echo "type=Bug" >> "$GITHUB_OUTPUT"
           else
@@ -76,13 +76,13 @@ jobs:
       - name: Add GitHub issue URL to Jira issue
         run: |
           curl --request POST \
-               --url "${{ inputs.jira-base-url }}/rest/api/3/issue/${{ steps.create.outputs.issue }}/remotelink" \
-               --user "${{ secrets.jira-user-email }}:${{ secrets.jira-api-token }}" \
+               --url '${{ inputs.jira-base-url }}/rest/api/3/issue/${{ steps.create.outputs.issue }}/remotelink' \
+               --user '${{ secrets.jira-user-email }}:${{ secrets.jira-api-token }}' \
                --header "Accept: application/json" \
                --header "Content-Type: application/json" \
                --data '{"object": {"url": "${{ github.event.issue.html_url }}", "title": "Issue #${{ github.event.issue.number }} · ${{ github.repository }}"}}'
       - name: Comment Jira issue URL on GitHub issue
-        run: gh issue comment "${{ github.event.issue.number }}" --body "${{ inputs.jira-base-url }}/browse/${{ steps.create.outputs.issue }}" --repo "${{ github.repository }}"
+        run: gh issue comment '${{ github.event.issue.number }}' --body '${{ inputs.jira-base-url }}/browse/${{ steps.create.outputs.issue }}' --repo '${{ github.repository }}'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -149,29 +149,29 @@ jobs:
       - name: Determine Jira issue transition ID
         id: transition-id
         run: |
-          if "${{ github.event.action == 'closed' && github.event.issue.state_reason == 'completed' }}"
+          if '${{ github.event.action == 'closed' && github.event.issue.state_reason == 'completed' }}'
           then
             echo "name=Done" >> "$GITHUB_OUTPUT"
             echo "id=61" >> "$GITHUB_OUTPUT"
-          elif "${{ github.event.action == 'closed' && github.event.issue.state_reason == 'not_planned' }}"
+          elif '${{ github.event.action == 'closed' && github.event.issue.state_reason == 'not_planned' }}'
           then
             echo "name=Rejected" >> "$GITHUB_OUTPUT"
             echo "id=71" >> "$GITHUB_OUTPUT"
-          elif "${{ github.event.action == 'reopened'}}"
+          elif '${{ github.event.action == 'reopened'}}'
           then
             echo "name=Untriaged" >> "$GITHUB_OUTPUT"
             echo "id=81" >> "$GITHUB_OUTPUT"
           else
-            echo "github.event.action=${{ github.event.action }}"
-            echo "github.event.issue.state_reason=${{ github.event.issue.state_reason }}"
+            echo 'github.event.action=${{ github.event.action }}'
+            echo 'github.event.issue.state_reason=${{ github.event.issue.state_reason }}'
             echo "Unknown transition"
             exit 1
           fi
       - name: Transition issue to ${{ steps.transition-id.outputs.name }}
         run: |
           curl --request POST \
-            --url "${{ inputs.jira-base-url }}/rest/api/3/issue/${{ steps.get-jira-issue-key.outputs.jira_issue_key }}/transitions" \
-            --user "${{ secrets.jira-user-email }}:${{ secrets.jira-api-token }}" \
+            --url '${{ inputs.jira-base-url }}/rest/api/3/issue/${{ steps.get-jira-issue-key.outputs.jira_issue_key }}/transitions' \
+            --user '${{ secrets.jira-user-email }}:${{ secrets.jira-api-token }}' \
             --header "Accept: application/json" \
             --header "Content-Type: application/json" \
             --data '{"transition": {"id": "${{ steps.transition-id.outputs.id }}"}}'

--- a/.github/workflows/update_bundle.yaml
+++ b/.github/workflows/update_bundle.yaml
@@ -64,13 +64,13 @@ jobs:
       - name: Update bundle file
         id: update-file
         working-directory: bundle-repo
-        run: python3 ../workflow-repo/update_bundle.py "${{ inputs.path-to-bundle-file }}"
+        run: python3 ../workflow-repo/update_bundle.py '${{ inputs.path-to-bundle-file }}'
       - name: Push `update-bundle` branch
         if: ${{ fromJSON(steps.update-file.outputs.updates_available) }}
         working-directory: bundle-repo
         run: |
           git checkout -b update-bundle
-          git add "${{ inputs.path-to-bundle-file }}"
+          git add '${{ inputs.path-to-bundle-file }}'
           git config user.name "GitHub Actions"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "Update bundle"
@@ -87,6 +87,6 @@ jobs:
             echo Open pull request already exists
             exit 0
           fi
-          gh pr create --head update-bundle --title "Update bundle" --body "Update charm revisions in bundle YAML file" --reviewer "${{ inputs.reviewers }}"
+          gh pr create --head update-bundle --title "Update bundle" --body "Update charm revisions in bundle YAML file" --reviewer '${{ inputs.reviewers }}'
         env:
           GH_TOKEN: ${{ secrets.token }}


### PR DESCRIPTION
GitHub expressions should not contain shell expansions