### PR TITLE
breaking(build_charms_with_cache.yaml): Remove `charms` output (JSON string of charms built)

### DIFF
--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -25,27 +25,6 @@ on:
       artifact-name:
         description: Charm packages are uploaded to this GitHub artifact name
         value: ${{ inputs.artifact-name }}
-      charms:
-        description: JSON string of charms built
-        value: ${{ jobs.collect-charms.outputs.charms }}
-        # Example:
-        # [
-        #   {
-        #     "bases_index": 0, # corresponds to charmcraft.yaml file
-        #     "directory_path": ".",
-        #     "file_path": "./mysql_ubuntu-20.04-amd64.charm"
-        #   },
-        #   {
-        #     "bases_index": 1,
-        #     "directory_path": ".",
-        #     "file_path": "./mysql_ubuntu-22.04-amd64.charm"
-        #   },
-        #   {
-        #     "bases_index": 0,
-        #     "directory_path": "tests/integration/relations/application-charm",
-        #     "file_path": "./tests/integration/relations/application-charm/application_ubuntu-22.04-amd64.charm"
-        #   }
-        # ]
 
 jobs:
   get-workflow-version:
@@ -76,7 +55,7 @@ jobs:
     strategy:
       matrix:
         charm: ${{ fromJSON(needs.collect-charms.outputs.charms) }}
-    name: ${{ matrix.charm._job_display_name }}
+    name: ${{ matrix.charm.job_display_name }}
     needs:
       - collect-charms
     runs-on: ubuntu-latest

--- a/python/cli/data_platform_workflows_cli/collect_charms.py
+++ b/python/cli/data_platform_workflows_cli/collect_charms.py
@@ -3,49 +3,30 @@
 """Collect charms to build from charmcraft.yaml file(s)"""
 
 import json
-import os
 import logging
+import os
+import pathlib
 import sys
-from pathlib import Path
 
 import yaml
-
-
-def get_base_versions(path_to_charmcraft_yaml: Path) -> list[str]:
-    """Reads Ubuntu versions of bases from charmcraft.yaml.
-
-    Args:
-        path_to_charmcraft_yaml: Path to charmcraft.yaml file
-
-    Returns:
-        List of Ubuntu versions (e.g. ["20.04", "22.04"])
-    """
-    yaml_data = yaml.safe_load(path_to_charmcraft_yaml.read_text())
-    if (type := yaml_data["type"]) != "charm":
-        logging.info(
-            f"{path_to_charmcraft_yaml} is {type=} instead of 'charm', skipping"
-        )
-        return []
-    bases = yaml_data["bases"]
-    # Handle multiple bases formats
-    # See https://discourse.charmhub.io/t/charmcraft-bases-provider-support/4713
-    versions = [base.get("build-on", [base])[0]["channel"] for base in bases]
-    return versions
 
 
 def main():
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)
     charms = []
-    for charmcraft_yaml in Path(".").glob("**/charmcraft.yaml"):
+    for charmcraft_yaml in pathlib.Path(".").glob("**/charmcraft.yaml"):
+        yaml_data = yaml.safe_load(charmcraft_yaml.read_text())
+        if (type_ := yaml_data["type"]) != "charm":
+            logging.info(f'{charmcraft_yaml} is {type_=} instead of "charm", skipping')
+            continue
         path = charmcraft_yaml.parent
         charm_name = yaml.safe_load((path / "metadata.yaml").read_text())["name"]
-        for index, version in enumerate(get_base_versions(charmcraft_yaml)):
+        for bases_index, _ in enumerate(yaml_data["bases"]):
             charms.append(
                 {
-                    "_job_display_name": f"Build {charm_name} charm | {version}",
-                    "bases_index": index,
-                    "directory_path": path.as_posix(),
-                    "file_path": f"./{path/charm_name}_ubuntu-{version}-amd64.charm",
+                    "job_display_name": f"Build {charm_name} charm | base #{bases_index}",
+                    "bases_index": bases_index,
+                    "directory_path": str(path),
                 }
             )
     logging.info(f"Collected {charms=}")


### PR DESCRIPTION
Instead of using the JSON string, integration tests should instead download the GitHub artifact and check if a *.charm file exists

If there are multiple *.charm files in a directory, the integration test job should use an input to determine which *.charm file to select (example input: Ubuntu version)

This change makes build_charms_with_cache.yaml more consistent/interchangeable with build_charm_without_cache.yaml