### PR TITLE
compatible: Prefer `tox run -e build` over `charmcraft pack` in build charm workflows

### DIFF
--- a/.github/workflows/build_charm_without_cache.yaml
+++ b/.github/workflows/build_charm_without_cache.yaml
@@ -38,10 +38,18 @@ jobs:
           sudo iptables -P FORWARD ACCEPT
           
           sudo snap install charmcraft --classic
+          pipx install tox
+          pipx install poetry
       - name: Pack charm
         id: pack
         working-directory: ${{ inputs.path-to-charm-directory }}
-        run: sg lxd -c "charmcraft pack"
+        run: |
+          if tox list --no-desc | grep --fixed-strings --line-regexp build
+          then
+            sg lxd -c "tox run -e build"
+          else
+            sg lxd -c "charmcraft pack"
+          fi
       - name: Upload charmcraft logs
         if: ${{ failure() && steps.pack.outcome == 'failure' }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -93,6 +93,8 @@ jobs:
           sudo iptables -P FORWARD ACCEPT
           
           sudo snap install charmcraft --classic
+          pipx install tox
+          pipx install poetry
       - name: Get charmcraft version
         id: charmcraft-version
         # Major and minor versions (e.g. "2.1")
@@ -102,7 +104,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ~/ga-charmcraft-cache/**
-          key: charmcraft-pack-${{ matrix.charm.directory_path }}-${{ matrix.charm.bases_index }}-${{ steps.charmcraft-version.outputs.version }}-${{ hashFiles(format('{0}/charmcraft.yaml', matrix.charm.directory_path), format('{0}/requirements.txt', matrix.charm.directory_path)) }}
+          key: charmcraft-pack-${{ matrix.charm.directory_path }}-${{ matrix.charm.bases_index }}-${{ steps.charmcraft-version.outputs.version }}-${{ hashFiles(format('{0}/charmcraft.yaml', matrix.charm.directory_path), format('{0}/poetry.lock', matrix.charm.directory_path), format('{0}/requirements.txt', matrix.charm.directory_path)) }}
       - name: Import cached containers
         if: ${{ steps.restore-cache.outputs.cache-hit }}
         run: |
@@ -134,7 +136,13 @@ jobs:
       - name: Pack charm
         id: pack
         working-directory: ${{ matrix.charm.directory_path }}
-        run: sg lxd -c "charmcraft pack --bases-index='${{ matrix.charm.bases_index }}'"
+        run: |
+          if tox list --no-desc | grep --fixed-strings --line-regexp build
+          then
+            sg lxd -c "tox run -e build -- --bases-index='${{ matrix.charm.bases_index }}'"
+          else
+            sg lxd -c "charmcraft pack --bases-index='${{ matrix.charm.bases_index }}'"
+          fi
       - name: Upload charmcraft logs
         if: ${{ failure() && steps.pack.outcome == 'failure' }}
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
`tox run -e build` was added to support Poetry (and to version control poetry.lock instead of requirements.txt). Example: https://github.com/canonical/mysql-operator/pull/192