### PR TITLE
patch: Increase build timeout to 2 hours (from 1 hour)

### DIFF
--- a/.github/workflows/build_charm_without_cache.yaml
+++ b/.github/workflows/build_charm_without_cache.yaml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build charm
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -78,7 +78,7 @@ jobs:
     needs:
       - collect-charms
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Some builds are taking longer than 1 hour. Example: https://github.com/canonical/mysql-operator/actions/runs/5622519030/job/15235355145