### PR TITLE
patch(build_charms_with_cache.yaml): Use full charmcraft version in cache key

### DIFF
--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -97,8 +97,7 @@ jobs:
           pipx install poetry
       - name: Get charmcraft version
         id: charmcraft-version
-        # Major and minor versions (e.g. "2.1")
-        run: echo "version=$(charmcraft version | cut --delimiter '.' --fields 1,2)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(charmcraft version)" >> "$GITHUB_OUTPUT"
       - name: Restore cache of `charmcraft pack` LXC instance
         id: restore-cache
         uses: actions/cache/restore@v3


### PR DESCRIPTION
charmcraft 2.3.1 included [a change to how requirements are handled](https://github.com/canonical/charmcraft/pull/1157)

Before, we created a new cache if the minor version of charmcraft changed (e.g. 2.3 to 2.4). However, this example shows that we should create a new cache whenever the charmcraft version changes (e.g. 2.3.0 to 2.3.1)

Given that 2.3.1 is the first charmcraft patch release since 2.0.0, this PR shouldn't significantly affect how often caches are re-created after charmcraft updates