### PR TITLE
breaking(build_charms_with_cache.yaml): Use subset of poetry.lock in cache key

### DIFF
--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Get charmcraft version
         id: charmcraft-version
         run: echo "version=$(charmcraft version)" >> "$GITHUB_OUTPUT"
-      - name: Export charm requirements (for charms with poetry.lock)
+      - name: Export charm requirements from poetry.lock
         # `tox run -e pack-wrapper` will create a `requirements-last-build.txt` that is identical
         # to the `requirements.txt` file that will be used later during `charmcraft pack`.
         # We use `requirements-last-build.txt` instead of `poetry.lock` to generate the cache key.


### PR DESCRIPTION
`poetry.lock` contains charm dependencies and non-charm dependencies. Only when charm dependencies change we need to create a new cache.

This PR replaces (in the cache key) `poetry.lock` with `requirements-last-build.txt` which is generated by a tox `pack-wrapper` environment.

`requirements-last-build.txt` is a misleading name in this context. Normally, it would be generated after a `charmcraft pack` by running `tox run -e build`. However, when we run `tox run -e pack-wrapper`, the `charmcraft pack` step is skipped—so there was no "last build".

`requirements-last-build.txt` is identical to the `requirements.txt` file that would have been used during `charmcraft pack`.

---

This PR is only a breaking change for charms that have implemented a `build` tox environment which was added in #59. No dependent repositories have implemented this, so this change will not break any repositories. It will only break this PR: https://github.com/canonical/mysql-operator/pull/192