### PR TITLE
patch(pytest_plugins/pytest_operator_cache): Remove `charmcraft` from pytest-operator `check_deps`

### DIFF
--- a/python/pytest_plugins/pytest_operator_cache/pytest_operator_cache/plugin.py
+++ b/python/pytest_plugins/pytest_operator_cache/pytest_operator_cache/plugin.py
@@ -10,6 +10,12 @@ def pytest_configure(config):
         plugin = config.pluginmanager.get_plugin("pytest-operator")
         plugin.OpsTest.build_charm = build_charm
 
+        # Remove charmcraft dependency from `ops_test` fixture
+        check_deps = plugin.check_deps
+        plugin.check_deps = lambda *deps: check_deps(
+            *(dep for dep in deps if dep != "charmcraft")
+        )
+
 
 async def build_charm(self, charm_path: str | os.PathLike, bases_index: int = None) -> str:
     charm_path = pathlib.Path(charm_path)


### PR DESCRIPTION
pytest-operator `ops_test` requires that charmcraft is installed: https://github.com/charmed-kubernetes/pytest-operator/blob/9e0c8f3b4feb848e097391317c5a0a09d43bd3f4/pytest_operator/plugin.py#L229