### PR TITLE
patch(pytest_plugins/pytest_operator_groups): Run modifyitems hook last

### DIFF
--- a/python/pytest_plugins/pytest_operator_groups/pytest_operator_groups/plugin.py
+++ b/python/pytest_plugins/pytest_operator_groups/pytest_operator_groups/plugin.py
@@ -21,6 +21,9 @@ def pytest_configure(config):
     )
     if config.option.collect_groups:
         config.option.collectonly = True
+        assert (
+            config.option.group is None
+        ), "--group should not be used with --collect-groups"
 
 
 def _get_group_number(function) -> typing.Optional[int]:
@@ -77,6 +80,7 @@ def _collect_groups(items):
         file.write(output)
 
 
+@pytest.hookimpl(trylast=True)  # Run after tests are deselected with `-m`
 def pytest_collection_modifyitems(config, items):
     if config.option.collect_groups:
         _collect_groups(items)


### PR DESCRIPTION
pytest_collection_modifyitems hook in plugin.py should run after tests are deselected with `-m` (e.g. `pytest -m "not unstable"`) so that a GitHub runner is not provisioned for an empty group