### PR TITLE
patch(build_charms_with_cache.yaml): Disable charmcraft snap refresh in cached LXC containers

### DIFF
--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -188,6 +188,7 @@ jobs:
             # Disable charmcraft snap updates
             # Workaround (unconfirmed) for https://github.com/canonical/charmcraft/issues/1202
             sg lxd -c "lxc --project charmcraft start \"$container_name_with_inode\""
+            sg lxd -c "lxc --project charmcraft exec \"$container_name_with_inode\" -- bash -c 'while ! systemctl is-active snapd.service; do sleep 0.5; done'"
             sg lxd -c "lxc --project charmcraft exec \"$container_name_with_inode\" -- snap refresh --hold=forever charmcraft"
             sg lxd -c "lxc --project charmcraft stop \"$container_name_with_inode\""
 


### PR DESCRIPTION
And add charmcraft snap revision to cache key

Potential workaround for https://github.com/canonical/charmcraft/issues/1202