### PR TITLE
patch(integration-test-charm.yaml): Pass proxy env vars (e.g. `HTTPS_PROXY`) to Juju machines

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -176,8 +176,9 @@ jobs:
           mkdir -p ~/.local/share/juju  # Workaround for juju 3 strict snap
           juju bootstrap "${{ inputs.cloud }}" "${{ steps.parse-versions.outputs.agent_bootstrap_option }}"
           # `https-proxy` sets `HTTPS_PROXY` environment variable inside Juju machines
+          # (same for `http-proxy` -> `HTTP_PROXY` and `no-proxy` -> `NO_PROXY`)
           # Self-hosted runners require proxy
-          juju model-defaults logging-config='<root>=INFO; unit=DEBUG' https-proxy="$HTTPS_PROXY"
+          juju model-defaults logging-config='<root>=INFO; unit=DEBUG' http-proxy="$HTTP_PROXY" https-proxy="$HTTPS_PROXY" no-proxy="$NO_PROXY"
           juju add-model test
           pipx install tox
           pipx install poetry


### PR DESCRIPTION
Fixes backup integration tests on self-hosted runners