### PR TITLE
patch(pytest_plugins): Add python 3.8 compatability

### DIFF
--- a/_check_semantic_version_prefix.py
+++ b/_check_semantic_version_prefix.py
@@ -11,9 +11,9 @@ import os
 
 
 class PrefixValueError(ValueError):
-    def __init__(self, message: str):
+    def __init__(self, message_: str):
         super().__init__(
-            f"Message does not contain valid semantic version prefix (see CONTRIBUTING.md). {message=}"
+            f"Message does not contain valid semantic version prefix (see CONTRIBUTING.md). {message_=}"
         )
 
 

--- a/python/pytest_plugins/github_secrets/github_secrets/plugin.py
+++ b/python/pytest_plugins/github_secrets/github_secrets/plugin.py
@@ -1,5 +1,6 @@
 import ast
 import os
+
 import pytest
 
 

--- a/python/pytest_plugins/github_secrets/pyproject.toml
+++ b/python/pytest_plugins/github_secrets/pyproject.toml
@@ -14,7 +14,7 @@ packages = [{include = "github_secrets"}]
 github_secrets = "github_secrets.plugin"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 
 
 [build-system]

--- a/python/pytest_plugins/pytest_operator_cache/pyproject.toml
+++ b/python/pytest_plugins/pytest_operator_cache/pyproject.toml
@@ -14,7 +14,7 @@ packages = [{include = "pytest_operator_cache"}]
 operator_cache = "pytest_operator_cache.plugin"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 pyyaml = "*"
 
 

--- a/python/pytest_plugins/pytest_operator_cache/pytest_operator_cache/plugin.py
+++ b/python/pytest_plugins/pytest_operator_cache/pytest_operator_cache/plugin.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import typing
 
 import yaml
 
@@ -18,7 +19,7 @@ def pytest_configure(config):
 
 
 async def build_charm(
-    self, charm_path: str | os.PathLike, bases_index: int = None
+    self, charm_path: typing.Union[str, os.PathLike], bases_index: int = None
 ) -> pathlib.Path:
     charm_path = pathlib.Path(charm_path)
     if bases_index is not None:

--- a/python/pytest_plugins/pytest_operator_groups/pyproject.toml
+++ b/python/pytest_plugins/pytest_operator_groups/pyproject.toml
@@ -14,7 +14,7 @@ packages = [{include = "pytest_operator_groups"}]
 operator_groups = "pytest_operator_groups.plugin"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 pytest = "*"
 
 


### PR DESCRIPTION
Subordinate charms (e.g. MySQL Router for machines) need to support python 3.8

Previously, those charms could not install the pytest_plugins since the plugins required python 3.10+ and Poetry resolves all dependencies together