### PR TITLE
[MISC] Adding include and exclude arguments to update_bundle workflow

### DIFF
--- a/.github/workflows/update_bundle.md
+++ b/.github/workflows/update_bundle.md
@@ -18,6 +18,8 @@ jobs:
     with:
       path-to-bundle-file: bundle.yaml
       reviewers: canonical/data-platform-engineers,octocat
+      include: app1       # If include is not provided, all apps will be updated
+      exclude: app3,app4  # Except those provided in the exclude option. 
     secrets:
       token: ${{ secrets.CREATE_PR_APP_TOKEN }}
 ```

--- a/.github/workflows/update_bundle.yaml
+++ b/.github/workflows/update_bundle.yaml
@@ -67,9 +67,9 @@ jobs:
         run: |
           CMD="update-bundle '${{ inputs.path-to-bundle-file }}'"
           
-          if [ ! -z ${{ inputs.include }} ]; then CMD="${CMD} --include ${{ inputs.include }}"; fi
+          if [ ! -z "${{ inputs.include }}" ]; then CMD="${CMD} --include ${{ inputs.include }}"; fi
           
-          if [ ! -z ${{ inputs.exclude }} ]; then CMD="${CMD} --exclude ${{ inputs.exclude }}"; fi
+          if [ ! -z "${{ inputs.exclude }}" ]; then CMD="${CMD} --exclude ${{ inputs.exclude }}"; fi
           
           echo "Executing command $CMD"
           

--- a/.github/workflows/update_bundle.yaml
+++ b/.github/workflows/update_bundle.yaml
@@ -14,6 +14,14 @@ on:
         description: Comma separated list of GitHub usernames to request to review pull request (e.g. "canonical/data-platform-engineers,octocat")
         required: false
         type: string
+      include:
+        description: Comma separated list of applications to be checked against updates
+        required: false
+        type: string
+      exclude:
+        description: Comma separated list of applications to NOT be checked against updates
+        required: false
+        type: string
     secrets:
       token:
         description: |
@@ -56,7 +64,16 @@ jobs:
           token: ${{ secrets.token }}
       - name: Update bundle file
         id: update-file
-        run: update-bundle '${{ inputs.path-to-bundle-file }}'
+        run: |
+          CMD="update-bundle '${{ inputs.path-to-bundle-file }}'"
+          
+          if [ ! -z ${{ inputs.include }} ]; then CMD="${CMD} --include ${{ inputs.include }}"; fi
+          
+          if [ ! -z ${{ inputs.exclude }} ]; then CMD="${CMD} --exclude ${{ inputs.exclude }}"; fi
+          
+          echo "Executing command $CMD"
+          
+          $CMD
       - name: Push `update-bundle` branch
         if: ${{ fromJSON(steps.update-file.outputs.updates_available) }}
         run: |

--- a/python/cli/README.md
+++ b/python/cli/README.md
@@ -1,3 +1,11 @@
 Internal Python CLI intended to be executed by reusable workflows in this repository.
 
 This CLI should **not** be used outside this repository.
+
+### Running tests
+
+In order to run the tests
+
+```bash
+poetry run python -m unittest
+```

--- a/python/cli/tests/test_update_bundle.py
+++ b/python/cli/tests/test_update_bundle.py
@@ -1,0 +1,74 @@
+import unittest
+
+from data_platform_workflows_cli.update_bundle import filter_application, parser
+
+
+class TestUpdateBundle(unittest.TestCase):
+
+    def test_filter_application_include_ok(self):
+        assert filter_application("package1", ["package1"], [])
+
+    def test_filter_application_include_ko(self):
+        assert not filter_application("package1", ["package2"], [])
+
+    def test_filter_application_exclude_ok(self):
+        assert filter_application("package1", [], [])
+
+    def test_filter_application_exclude_ko(self):
+        assert not filter_application("package1", [], ["package1"])
+
+    def test_filter_application_include_priority(self):
+        assert filter_application("package1", ["package1"], ["package1"])
+
+    def test_argument_parsing_vanilla(self):
+        args = parser.parse_args([
+            "my-file"
+        ])
+        self.assertEqual("my-file", args.file_path)
+        self.assertEqual([], args.include)
+        self.assertEqual([], args.exclude)
+
+    def test_argument_parsing_include(self):
+        args = parser.parse_args([
+            "my-file",
+            "--include", "package1", "--include", "package2"
+        ])
+        self.assertEqual("my-file", args.file_path)
+        self.assertEqual(["package1", "package2"], args.include)
+        self.assertEqual([], args.exclude)
+
+    def test_argument_parsing_include_comma_separated(self):
+        args = parser.parse_args([
+            "my-file",
+            "--include", "package1,package2"
+        ])
+        self.assertEqual("my-file", args.file_path)
+        self.assertEqual(["package1", "package2"], args.include)
+        self.assertEqual([], args.exclude)
+
+    def test_argument_parsing_exclude(self):
+        args = parser.parse_args([
+            "my-file",
+            "--exclude", "package1", "--exclude", "package2"
+        ])
+        self.assertEqual("my-file", args.file_path)
+        self.assertEqual([], args.include)
+        self.assertEqual(["package1", "package2"], args.exclude)
+
+    def test_argument_parsing_exclude_comma_separated(self):
+        args = parser.parse_args([
+            "my-file",
+            "--exclude", "package1,package2"
+        ])
+        self.assertEqual("my-file", args.file_path)
+        self.assertEqual([], args.include)
+        self.assertEqual(["package1", "package2"], args.exclude)
+
+    def test_argument_parsing_combined(self):
+        args = parser.parse_args([
+            "my-file",
+            "--exclude", "package1", "--include", "package2"
+        ])
+        self.assertEqual("my-file", args.file_path)
+        self.assertEqual(["package2"], args.include)
+        self.assertEqual(["package1"], args.exclude)


### PR DESCRIPTION
I thought this could be a valuable option to provide a bit more flexibility on picking the applications in the bundle we want to update, by excluding or including some. 

This should for instance serve the use-case when we want to keep have some bundle up to date, but some other apps (e.g. tls-certificate-operator) broke backwards compatibility. 