### PR TITLE
patch(integration_test_charm.yaml): Upgrade snapd and lxd

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -161,6 +161,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up environment
         run: |
+          # upgrade snapd if new version released
+          sudo snap refresh snapd
+          
+          # upgrade lxd; the version installed by default is 5.0
+          sudo snap refresh lxd --channel=5.17/stable  
+               
           # `--classic` applies to juju 2 snap; ignored for juju 3 snap
           sudo snap install juju --classic --channel="${{ steps.parse-versions.outputs.snap_channel }}"
       - name: Set up lxd


### PR DESCRIPTION
This PR upgrades the following:
- snapd: to include interfaces that were patched / added and that are required by our products
- lxd: to `5.17.0` - where [lxd bug](https://github.com/canonical/lxd/issues/12239) that makes some of our HA integ. tests has been fixed.