### PR TITLE
patch(release_charm.yaml): Increase timeout to 60 minutes

### DIFF
--- a/.github/workflows/release_charm.yaml
+++ b/.github/workflows/release_charm.yaml
@@ -54,7 +54,7 @@ jobs:
     needs:
       - get-workflow-version
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ needs.get-workflow-version.outputs.version }}'#subdirectory=python/cli


### PR DESCRIPTION
Uploading OCI image can take > 30 minutes

Example: https://github.com/canonical/spark-history-server-k8s-operator/actions/runs/6497401383/job/17657216001