### PR TITLE
patch: Remove quotes in `snap install` if no flag passed

### DIFF
--- a/.github/workflows/build_charm_without_cache.yaml
+++ b/.github/workflows/build_charm_without_cache.yaml
@@ -80,7 +80,7 @@ jobs:
           # (shellcheck sees it as constant, but GitHub Actions expression is not constant between workflow runs)
           if [[ '${{ steps.lxd-snap-version.outputs.install_flag }}' ]]
           then
-            sudo snap refresh lxd '${{ steps.lxd-snap-version.outputs.install_flag }}'
+            sudo snap refresh lxd ${{ steps.lxd-snap-version.outputs.install_flag }}
           fi
           sudo adduser "$USER" lxd
           # `newgrp` does not work in GitHub Actions; use `sg` instead
@@ -90,7 +90,7 @@ jobs:
           sudo iptables -F FORWARD
           sudo iptables -P FORWARD ACCEPT
 
-          sudo snap install charmcraft --classic '${{ steps.charmcraft-snap-version.outputs.install_flag }}'
+          sudo snap install charmcraft --classic ${{ steps.charmcraft-snap-version.outputs.install_flag }}
           pipx install tox
           pipx install poetry
       - name: Pack charm

--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -97,7 +97,7 @@ jobs:
           # (shellcheck sees it as constant, but GitHub Actions expression is not constant between workflow runs)
           if [[ '${{ steps.lxd-snap-version.outputs.install_flag }}' ]]
           then
-            sudo snap refresh lxd '${{ steps.lxd-snap-version.outputs.install_flag }}'
+            sudo snap refresh lxd ${{ steps.lxd-snap-version.outputs.install_flag }}
           fi
           sudo adduser "$USER" lxd
           # `newgrp` does not work in GitHub Actions; use `sg` instead
@@ -107,7 +107,7 @@ jobs:
           sudo iptables -F FORWARD
           sudo iptables -P FORWARD ACCEPT
 
-          sudo snap install charmcraft --classic '${{ steps.charmcraft-snap-version.outputs.install_flag }}'
+          sudo snap install charmcraft --classic ${{ steps.charmcraft-snap-version.outputs.install_flag }}
           pipx install tox
           pipx install poetry
       - name: Get charmcraft version

--- a/.github/workflows/release_charm.yaml
+++ b/.github/workflows/release_charm.yaml
@@ -62,7 +62,7 @@ jobs:
         id: charmcraft-snap-version
         run: parse-snap-version --revision='${{ inputs.charmcraft-snap-revision }}' --channel='${{ inputs.charmcraft-snap-channel }}' --revision-input-name=charmcraft-snap-revision --channel-input-name=charmcraft-snap-channel
       - name: Install charmcraft
-        run: sudo snap install charmcraft --classic '${{ steps.charmcraft-snap-version.outputs.install_flag }}'
+        run: sudo snap install charmcraft --classic ${{ steps.charmcraft-snap-version.outputs.install_flag }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Download charm package(s)

--- a/python/cli/data_platform_workflows_cli/parse_snap_version.py
+++ b/python/cli/data_platform_workflows_cli/parse_snap_version.py
@@ -14,9 +14,9 @@ def main():
         assert (
             not args.channel
         ), f"`{args.channel_input_name}` input cannot be used if `{args.revision_input_name}` input is passed"
-        output += f"--revision={args.revision}"
+        output += f"'--revision={args.revision}'"
     elif args.channel:
-        output += f"--channel={args.channel}"
+        output += f"'--channel={args.channel}'"
 
     print(output)
     with open(os.environ["GITHUB_OUTPUT"], "a") as file:


### PR DESCRIPTION
A recent change to `snap install` causes commands such as `snap install charmcraft ''` to fail.

Only add `''` if we're passing flags to `snap install`

Example failure: https://github.com/canonical/spark-history-server-k8s-operator/actions/runs/6506459332/job/17672046098?pr=20#step:6:27