### PR TITLE
breaking(integration_test_charm.yaml): Move from self-hosted to GitHub-hosted runners

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -171,7 +171,6 @@ jobs:
       - name: Set up environment
         run: |
           mkdir -p ~/.local/share/juju  # Workaround for juju 3 strict snap
-          #TODO microk8s: replace lxd with group name
           sg lxd -c "juju bootstrap '${{ inputs.cloud }}' '${{ steps.parse-versions.outputs.agent_bootstrap_option }}'"
           juju model-defaults logging-config='<root>=INFO; unit=DEBUG'
           juju add-model test


### PR DESCRIPTION
Self-hosted runners aren't yet stable enough to switch to entirely—but that shouldn't block switching to a reusable integration test workflow (which includes some quality of life improvements, like displaying juju debug-log)