### PR TITLE
patch: Install poetry-plugin-export

### DIFF
--- a/.github/workflows/build_charm_without_cache.yaml
+++ b/.github/workflows/build_charm_without_cache.yaml
@@ -94,6 +94,7 @@ jobs:
           pipx install tox
           pipx install poetry
           pipx inject poetry poetry-plugin-export
+          # TODO: Remove after https://github.com/python-poetry/poetry/pull/5980 is closed
           poetry config warnings.export false
       - name: Pack charm
         id: pack

--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -111,6 +111,7 @@ jobs:
           pipx install tox
           pipx install poetry
           pipx inject poetry poetry-plugin-export
+          # TODO: Remove after https://github.com/python-poetry/poetry/pull/5980 is closed
           poetry config warnings.export false
       - name: Get charmcraft version
         id: charmcraft-version


### PR DESCRIPTION
Poetry export functionality will be split off to a separate plugin.

Install the plugin and suppress the warning about it.