### PR TITLE
patch(_get_workflow_version.yaml): Use commit SHA instead of ref

### DIFF
--- a/.github/workflows/_get_workflow_version.yaml
+++ b/.github/workflows/_get_workflow_version.yaml
@@ -147,7 +147,7 @@ jobs:
           assert (
               len(versions) == 1
           ), f"""Caller workflow uses `{REUSABLE_WORKFLOW_FILE_NAME}` workflow on multiple versions {versions}.
-            Multiple versions not supported."""
+          Multiple versions not supported."""
 
           output = f"version={versions.pop()}"
           print(output)


### PR DESCRIPTION
If the ref (i.e. PR branch) is updated before _get_workflow_version.yaml is run, it will use the wrong commit to determine the workflow version in the calling workflow