### PR TITLE
breaking(build_charms_with_cache.yaml): Add workaround for charmcraft 2.5

### DIFF
--- a/.github/workflows/build_charms_with_cache.yaml
+++ b/.github/workflows/build_charms_with_cache.yaml
@@ -177,7 +177,7 @@ jobs:
           import os
 
           cache_directory = pathlib.Path.home() / "ga-charmcraft-cache/pip-cache"
-          cache_directory.mkdir()
+          cache_directory.mkdir(parents=True, exist_ok=True)
           with open(os.environ["GITHUB_OUTPUT"], "a") as file:
               file.write(f"cache_directory={str(cache_directory)}")
       - name: Pack charm


### PR DESCRIPTION
charmcraft 2.5's new caching implementation breaks this workflow. We plan to migrate to the new caching system, but are blocked by this bug: https://github.com/canonical/charmcraft/issues/1374. In the meantime, we can hack charmcraft 2.5's new caching system into the old caching system

Migration required for breaking change:
- old caches need to be deleted
- tox `build` environments (that wrap `charmcraft pack`) need to add `CRAFT_SHARED_CACHE` to pass_env