### PR TITLE
breaking(pytest_plugins/operator_groups): Raise exception if test missing group number

### DIFF
--- a/python/pytest_plugins/pytest_operator_groups/pytest_operator_groups/plugin.py
+++ b/python/pytest_plugins/pytest_operator_groups/pytest_operator_groups/plugin.py
@@ -61,7 +61,7 @@ def _collect_groups(items):
     for function in items:
         if (group_number := _get_group_number(function)) is None:
             raise Exception(
-                f"{function.name} missing group number. Docs: https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/integration_test_charm.md#step-3-split-test-functions-into-groups"
+                f"{function} missing group number. Docs: https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/integration_test_charm.md#step-3-split-test-functions-into-groups"
             )
         # Example: "integration.relations.test_database"
         name = function.module.__name__
@@ -104,7 +104,7 @@ def pytest_collection_modifyitems(config, items):
             group_number = _get_group_number(function)
             if group_number is None:
                 raise Exception(
-                    f"{function.name} missing group number. Docs: https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/integration_test_charm.md#step-3-split-test-functions-into-groups"
+                    f"{function} missing group number. Docs: https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/integration_test_charm.md#step-3-split-test-functions-into-groups"
                 )
             elif group_number == config.option.group:
                 filtered_items.append(function)


### PR DESCRIPTION
Fixes #106

If a test is missing a group number, it is almost certainly a mistake instead of intentional. Previously, if the test was missing a group number, it was marked as skipped (which will cause the job to pass on GitHub CI).