### PR TITLE
patch: Use subprocess.run instead of subprocess.capture_output

### DIFF
--- a/.github/workflows/_get_workflow_version.yaml
+++ b/.github/workflows/_get_workflow_version.yaml
@@ -100,7 +100,7 @@ jobs:
                       "git checkout FETCH_HEAD",
                   ]
               for command in commands:
-                  subprocess.check_output(command.split(" "), cwd=repository_name)
+                  subprocess.run(command.split(" "), cwd=repository_name, check=True)
 
               jobs = yaml.safe_load(caller_workflow_file_path.read_text())["jobs"]
               versions_ = set()

--- a/.github/workflows/sync_issue_to_jira.yaml
+++ b/.github/workflows/sync_issue_to_jira.yaml
@@ -103,7 +103,7 @@ jobs:
 
           def run_gh_cli(*args):
               """Run command with GitHub CLI"""
-              output = subprocess.check_output(
+              output = subprocess.run(
                   [
                       "gh",
                       "api",
@@ -112,8 +112,11 @@ jobs:
                       "-H",
                       "X-GitHub-Api-Version: 2022-11-28",
                       *args,
-                  ]
-              )
+                  ],
+                  check=True,
+                  capture_output=True,
+                  encoding="utf-8",
+              ).stdout
               return json.loads(output)
 
 


### PR DESCRIPTION
New syntax (.run added to Python after .capture_output)