### PR TITLE
patch: Add Allure Report beta

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -317,7 +317,7 @@ jobs:
         env:
           SECRETS_FROM_GITHUB: ${{ secrets.integration-test }}
       - name: (beta) Upload Allure results
-        if: ${{ (success() || (failure() && steps.tests.outcome == 'failure')) && inputs._beta_allure_report && github.run_attempt == '1' }}
+        if: ${{ (success() || (failure() && steps.tests.outcome == 'failure')) && inputs._beta_allure_report && github.event_name == 'schedule' && github.run_attempt == '1' }}
         uses: actions/upload-artifact@v4
         with:
           name: allure-results-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || inputs.juju-snap-channel }}-${{ matrix.groups.artifact_group_id }}
@@ -347,7 +347,7 @@ jobs:
   allure-report:
     # TODO future improvement: use concurrency group for job
     name: (beta) Publish Allure report
-    if: ${{ !cancelled() && inputs._beta_allure_report && github.run_attempt == '1'}}
+    if: ${{ !cancelled() && inputs._beta_allure_report && github.event_name == 'schedule' && github.run_attempt == '1'}}
     needs:
       - integration-test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Usage
> [!WARNING]
> This feature is in beta and **not part of the public interface**. It is subject to breaking changes or removal on a patch version bump.

1. `poetry add --group integration allure-pytest`
2. Set `_beta_allure_report: true` for **one** instance of `integration_test_charm.yaml`. If `integration_test_charm.yaml` is called with a matrix, `_beta_allure_report` can only be `true` for one combination of the matrix.
3. Add permission to `integration_test_charm.yaml` job and all calling workflows
```yaml
    permissions:
      contents: write  # Needed for Allure Report beta
```
4. Create gh pages branch
https://github.com/canonical/data-platform-workflows/blob/5a2c81678ff8733345875235e579d0b1fffbc894/.github/workflows/integration_test_charm.yaml#L363-L371
5. Enable gh pages publishing at https://github.com/canonical/mysql-router-k8s-operator/settings/pages (replace `mysql-router-k8s-operator` with repository name)
![gh-pages](https://github.com/canonical/data-platform-workflows/assets/115640263/6ee80a1e-f75b-4d67-b11f-977358c32847)

Example for 1-3: https://github.com/canonical/mysql-router-k8s-operator/pull/198