### PR TITLE
compatible(pytest_plugins/pytest_operator_groups): Allow str group ID

### DIFF
--- a/.github/workflows/integration_test_charm.md
+++ b/.github/workflows/integration_test_charm.md
@@ -61,7 +61,7 @@ Add
 ```python
 @pytest.mark.group(1)
 ```
-to every test function. Replace `1` with the group number.
+to every test function. Replace `1` with the group ID.
 
 #### Deciding how to split tests into groups
 Take a look at this Discourse post: https://discourse.charmhub.io/t/faster-ci-results-by-running-integration-tests-in-parallel/8816

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -313,7 +313,7 @@ jobs:
               file.write(output)
       - name: Run integration tests
         id: tests
-        run: sg '${{ steps.parse-cloud.outputs.group }}' -c "tox run -e integration -- '${{ matrix.groups.path_to_test_file }}' --group='${{ matrix.groups.group_number }}' -m '${{ steps.select-test-stability.outputs.mark_expression }}' --model test ${{ steps.allure-option.outputs.option }}"
+        run: sg '${{ steps.parse-cloud.outputs.group }}' -c "tox run -e integration -- '${{ matrix.groups.path_to_test_file }}' --group='${{ matrix.groups.group_id }}' -m '${{ steps.select-test-stability.outputs.mark_expression }}' --model test ${{ steps.allure-option.outputs.option }}"
         env:
           SECRETS_FROM_GITHUB: ${{ secrets.integration-test }}
       - name: (beta) Upload Allure results


### PR DESCRIPTION
Allow `str` group ID in addition to `int`

Closes #132