### PR TITLE
patch(build_charm.yaml): Fix support for extended charmcraft.yaml base format

### DIFF
--- a/python/cli/data_platform_workflows_cli/craft_tools/collect_bases.py
+++ b/python/cli/data_platform_workflows_cli/craft_tools/collect_bases.py
@@ -68,9 +68,10 @@ def get_bases(*, craft_: Craft, yaml_data):
             build_on_architectures = platform["build-on"]
         elif craft_ is Craft.CHARM:
             # https://discourse.charmhub.io/t/charmcraft-bases-provider-support/4713
-            build_on_architectures = (platform.get("build-on") or platform).get(
-                "architectures"
-            )
+            build_on = platform.get("build-on")
+            if build_on:
+                assert isinstance(build_on, list) and len(build_on) == 1
+            build_on_architectures = (build_on[0] or platform).get("architectures")
             if not build_on_architectures:
                 # Default to X64
                 arch_for_bases.append(craft.Architecture.X64)


### PR DESCRIPTION
https://discourse.charmhub.io/t/charmcraft-bases-provider-support/4713

charmcraft.yaml bases with build-on are a singleton list of one dict, not a dict

Follow up to #141

Encountered on https://github.com/canonical/postgresql-k8s-operator/actions/runs/8073677258/job/22057758552?pr=403