### PR TITLE
patch: Add _sync_docs.yaml

### DIFF
--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -23,8 +23,6 @@ jobs:
   sync-docs:
     name: Sync docs from discourse
     uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@v0.0.0
-    with:
-      discourse_host: discourse.charmhub.io
     secrets:
       discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
       discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}

--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -32,34 +32,46 @@ jobs:
 ```
 
 ## Run schedule
-
-|             repository            |   run time  |     cron      |
+### SQL
+| repository | run time | cron |
 |:---------------------------------:|:-----------:|:-------------:|
-| mysql-k8s-operator                | 12:10:00 AM | `10 00 * * *` |
-| mysql-operator                    | 12:20:00 AM | `20 00 * * *` |
-| postgresql-k8s-operator           | 12:30:00 AM | `30 00 * * *` |
-| postgresql-operator               | 12:40:00 AM | `40 00 * * *` |
-| mongodb-k8s-operator              | 12:50:00 AM | `50 00 * * *` |
-| mongodb-operator                  |  1:00:00 AM | `00 01 * * *` |
-| redis-k8s-operator                |  1:10:00 AM | `10 01 * * *` |
-| redis-operator                    |  1:20:00 AM | `20 01 * * *` |
-| opensearch-k8s-operator           |  1:30:00 AM | `30 01 * * *` |
-| opensearch-operator               |  1:40:00 AM | `40 01 * * *` |
-| kafka-k8s-operator                |  1:50:00 AM | `50 01 * * *` |
-| kafka-operator                    |  2:00:00 AM | `00 02 * * *` |
-| spark-history-server-k8s-operator |  2:10:00 AM | `10 02 * * *` |
-| data-integrator                   |  2:20:00 AM | `20 02 * * *` |
-| s3-integrator                     |  2:30:00 AM | `30 02 * * *` |
-| data-platform-libs                |  2:40:00 AM | `40 02 * * *` |
-| kafka-test-app                    |  2:50:00 AM | `50 02 * * *` |
-| mysql-test-app                    |  3:00:00 AM | `00 03 * * *` |
-| postgresql-test-app               |  3:10:00 AM | `10 03 * * *` |
-| mysql-router-k8s-operator         |  3:20:00 AM | `20 03 * * *` |
-| mysql-router-operator             |  3:30:00 AM | `30 03 * * *` |
-| pgbouncer-k8s-operator            |  3:40:00 AM | `40 03 * * *` |
-| pgbouncer-operator                |  3:50:00 AM | `50 03 * * *` |
-| zookeeper-k8s-operator            |  4:00:00 AM | `00 04 * * *` |
-| zookeeper-operator                |  4:10:00 AM | `10 04 * * *` |
-| opensearch-dashboards-operator    |  4:20:00 AM | `20 04 * * *` |
-| mongos-operator                   |  4:30:00 AM | `30 04 * * *` |
-| spark-client-snap                 |  4:40:00 AM | `40 04 * * *` |
+| mysql-k8s-operator | 12:10:00 AM | `10 00 * * *` |
+| mysql-operator | 12:20:00 AM | `20 00 * * *` |
+| mysql-test-app | 3:00:00 AM | `00 03 * * *` |
+| mysql-router-k8s-operator | 3:20:00 AM | `20 03 * * *` |
+| mysql-router-operator | 3:30:00 AM | `30 03 * * *` |
+| postgresql-k8s-operator | 12:30:00 AM | `30 00 * * *` |
+| postgresql-operator | 12:40:00 AM | `40 00 * * *` |
+| postgresql-test-app | 3:10:00 AM | `10 03 * * *` |
+| pgbouncer-k8s-operator | 3:40:00 AM | `40 03 * * *` |
+| pgbouncer-operator | 3:50:00 AM | `50 03 * * *` |
+
+### NoSQL
+| repository | run time | cron |
+|:---------------------------------:|:-----------:|:-------------:|
+| mongodb-k8s-operator | 12:50:00 AM | `50 00 * * *` |
+| mongodb-operator | 1:00:00 AM | `00 01 * * *` |
+| mongos-operator | 4:30:00 AM | `30 04 * * *` |
+| opensearch-k8s-operator | 1:30:00 AM | `30 01 * * *` |
+| opensearch-operator | 1:40:00 AM | `40 01 * * *` |
+| opensearch-dashboards-operator | 4:20:00 AM | `20 04 * * *` |
+| redis-k8s-operator | 1:10:00 AM | `10 01 * * *` |
+| redis-operator | 1:20:00 AM | `20 01 * * *` |
+
+### Big Data
+| repository | run time | cron |
+|:---------------------------------:|:-----------:|:-------------:|
+| kafka-k8s-operator | 1:50:00 AM | `50 01 * * *` |
+| kafka-operator | 2:00:00 AM | `00 02 * * *` |
+| kafka-test-app | 2:50:00 AM | `50 02 * * *` |
+| zookeeper-k8s-operator | 4:00:00 AM | `00 04 * * *` |
+| zookeeper-operator | 4:10:00 AM | `10 04 * * *` |
+| spark-history-server-k8s-operator | 2:10:00 AM | `10 02 * * *` |
+| spark-client-snap | 4:40:00 AM | `40 04 * * *` |
+
+### Other
+| repository | run time | cron |
+|:---------------------------------:|:-----------:|:-------------:|
+| data-integrator | 2:20:00 AM | `20 02 * * *` |
+| s3-integrator | 2:30:00 AM | `30 02 * * *` |
+| data-platform-libs | 2:40:00 AM | `40 02 * * *` |

--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -33,45 +33,45 @@ jobs:
 
 ## Run schedule
 ### SQL
-| repository | run time | cron |
-|:---------------------------------:|:-----------:|:-------------:|
-| mysql-k8s-operator | 12:10:00 AM | `10 00 * * *` |
-| mysql-operator | 12:20:00 AM | `20 00 * * *` |
-| mysql-test-app | 3:00:00 AM | `00 03 * * *` |
-| mysql-router-k8s-operator | 3:20:00 AM | `20 03 * * *` |
-| mysql-router-operator | 3:30:00 AM | `30 03 * * *` |
-| postgresql-k8s-operator | 12:30:00 AM | `30 00 * * *` |
-| postgresql-operator | 12:40:00 AM | `40 00 * * *` |
-| postgresql-test-app | 3:10:00 AM | `10 03 * * *` |
-| pgbouncer-k8s-operator | 3:40:00 AM | `40 03 * * *` |
-| pgbouncer-operator | 3:50:00 AM | `50 03 * * *` |
+| repository                | run time | cron          |
+|:-------------------------:|:--------:|:-------------:|
+| mysql-k8s-operator        | 12:10 AM | `10 00 * * *` |
+| mysql-operator            | 12:20 AM | `20 00 * * *` |
+| mysql-test-app            | 3:00 AM  | `00 03 * * *` |
+| mysql-router-k8s-operator | 3:20 AM  | `20 03 * * *` |
+| mysql-router-operator     | 3:30 AM  | `30 03 * * *` |
+| postgresql-k8s-operator   | 12:30 AM | `30 00 * * *` |
+| postgresql-operator       | 12:40 AM | `40 00 * * *` |
+| postgresql-test-app       | 3:10 AM  | `10 03 * * *` |
+| pgbouncer-k8s-operator    | 3:40 AM  | `40 03 * * *` |
+| pgbouncer-operator        | 3:50 AM  | `50 03 * * *` |
 
 ### NoSQL
-| repository | run time | cron |
-|:---------------------------------:|:-----------:|:-------------:|
-| mongodb-k8s-operator | 12:50:00 AM | `50 00 * * *` |
-| mongodb-operator | 1:00:00 AM | `00 01 * * *` |
-| mongos-operator | 4:30:00 AM | `30 04 * * *` |
-| opensearch-k8s-operator | 1:30:00 AM | `30 01 * * *` |
-| opensearch-operator | 1:40:00 AM | `40 01 * * *` |
-| opensearch-dashboards-operator | 4:20:00 AM | `20 04 * * *` |
-| redis-k8s-operator | 1:10:00 AM | `10 01 * * *` |
-| redis-operator | 1:20:00 AM | `20 01 * * *` |
+| repository                     | run time | cron          |
+|:------------------------------:|:--------:|:-------------:|
+| mongodb-k8s-operator           | 12:50 AM | `50 00 * * *` |
+| mongodb-operator               | 1:00 AM  | `00 01 * * *` |
+| mongos-operator                | 4:30 AM  | `30 04 * * *` |
+| opensearch-k8s-operator        | 1:30 AM  | `30 01 * * *` |
+| opensearch-operator            | 1:40 AM  | `40 01 * * *` |
+| opensearch-dashboards-operator | 4:20 AM  | `20 04 * * *` |
+| redis-k8s-operator             | 1:10 AM  | `10 01 * * *` |
+| redis-operator                 | 1:20 AM  | `20 01 * * *` |
 
 ### Big Data
-| repository | run time | cron |
-|:---------------------------------:|:-----------:|:-------------:|
-| kafka-k8s-operator | 1:50:00 AM | `50 01 * * *` |
-| kafka-operator | 2:00:00 AM | `00 02 * * *` |
-| kafka-test-app | 2:50:00 AM | `50 02 * * *` |
-| zookeeper-k8s-operator | 4:00:00 AM | `00 04 * * *` |
-| zookeeper-operator | 4:10:00 AM | `10 04 * * *` |
-| spark-history-server-k8s-operator | 2:10:00 AM | `10 02 * * *` |
-| spark-client-snap | 4:40:00 AM | `40 04 * * *` |
+| repository                        | run time | cron          |
+|:---------------------------------:|:--------:|:-------------:|
+| kafka-k8s-operator                | 1:50 AM  | `50 01 * * *` |
+| kafka-operator                    | 2:00 AM  | `00 02 * * *` |
+| kafka-test-app                    | 2:50 AM  | `50 02 * * *` |
+| zookeeper-k8s-operator            | 4:00 AM  | `00 04 * * *` |
+| zookeeper-operator                | 4:10 AM  | `10 04 * * *` |
+| spark-history-server-k8s-operator | 2:10 AM  | `10 02 * * *` |
+| spark-client-snap                 | 4:40 AM  | `40 04 * * *` |
 
 ### Other
-| repository | run time | cron |
-|:---------------------------------:|:-----------:|:-------------:|
-| data-integrator | 2:20:00 AM | `20 02 * * *` |
-| s3-integrator | 2:30:00 AM | `30 02 * * *` |
-| data-platform-libs | 2:40:00 AM | `40 02 * * *` |
+| repository         | run time | cron          |
+|:------------------:|:--------:|:-------------:|
+| data-integrator    | 2:20 AM  | `20 02 * * *` |
+| s3-integrator      | 2:30 AM  | `30 02 * * *` |
+| data-platform-libs | 2:40 AM  | `40 02 * * *` |

--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -22,7 +22,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from discourse
-    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml
+    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@v0.0.0
     with:
       discourse_host: discourse.charmhub.io
     secrets:

--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -5,6 +5,7 @@ Workflow file: [_sync_docs.yaml](_sync_docs.yaml)
 
 ## Usage
 Add `.yaml` file to `.github/workflows/`
+
 ```yaml
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
@@ -20,27 +21,19 @@ on:
 
 jobs:
   sync-docs:
-    name: Open PR with docs changes
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Open PR with docs changes
-        uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml
-        id: docs-pr
-        with:
-          discourse_host: discourse.charmhub.io
-          discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
-          discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dry_run: "true"
-      - name: Show migrate output
-        run: echo '${{ steps.docs-pr.outputs.migrate }}'
-      - name: Show reconcile output
-        run: echo '${{ steps.docs-pr.outputs.reconcile }}'
+    name: Sync docs from discourse
+    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml
+    with:
+      discourse_host: discourse.charmhub.io
+    secrets:
+      discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
+      discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
+      github_token: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write  # Needed to login to Discourse
       pull-requests: write  # Needed to create PR
 ```
+
 ## Run schedule
 
 |             repository            |   run time  |     cron      |

--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -1,5 +1,8 @@
 Workflow file: [_sync_docs.yaml](_sync_docs.yaml)
 
+> [!WARNING]
+> Subject to **breaking changes on patch release**. `_sync_docs.yaml` is experimental & not part of the public interface.
+
 ## Usage
 Add `.yaml` file to `.github/workflows/`
 ```yaml
@@ -19,9 +22,6 @@ jobs:
   sync-docs:
     name: Open PR with docs changes
     runs-on: ubuntu-latest
-    permissions:
-      contents: write  # Needed to login to Discourse
-      pull-requests: write # Needed to create PR
     steps:
       - uses: actions/checkout@v3
       - name: Open PR with docs changes
@@ -37,6 +37,9 @@ jobs:
         run: echo '${{ steps.docs-pr.outputs.migrate }}'
       - name: Show reconcile output
         run: echo '${{ steps.docs-pr.outputs.reconcile }}'
+    permissions:
+      contents: write  # Needed to login to Discourse
+      pull-requests: write  # Needed to create PR
 ```
 ## Run schedule
 

--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -35,43 +35,43 @@ jobs:
 ### SQL
 | repository                | run time | cron          |
 |:-------------------------:|:--------:|:-------------:|
-| mysql-k8s-operator        | 12:10 AM | `10 00 * * *` |
-| mysql-operator            | 12:20 AM | `20 00 * * *` |
-| mysql-test-app            | 3:00 AM  | `00 03 * * *` |
-| mysql-router-k8s-operator | 3:20 AM  | `20 03 * * *` |
-| mysql-router-operator     | 3:30 AM  | `30 03 * * *` |
-| postgresql-k8s-operator   | 12:30 AM | `30 00 * * *` |
-| postgresql-operator       | 12:40 AM | `40 00 * * *` |
-| postgresql-test-app       | 3:10 AM  | `10 03 * * *` |
-| pgbouncer-k8s-operator    | 3:40 AM  | `40 03 * * *` |
-| pgbouncer-operator        | 3:50 AM  | `50 03 * * *` |
+| mysql-k8s-operator        | 12:00 AM | `00 00 * * *` |
+| mysql-operator            | 12:10 AM | `10 00 * * *` |
+| mysql-test-app            | 12:20 AM | `20 00 * * *` |
+| mysql-router-k8s-operator | 12:30 AM | `30 00 * * *` |
+| mysql-router-operator     | 12:40 AM | `40 00 * * *` |
+| postgresql-k8s-operator   | 12:50 AM | `50 00 * * *` |
+| postgresql-operator       | 01:00 AM | `00 01 * * *` |
+| postgresql-test-app       | 01:10 AM | `10 01 * * *` |
+| pgbouncer-k8s-operator    | 01:20 AM | `20 01 * * *` |
+| pgbouncer-operator        | 01:30 AM | `30 01 * * *` |
 
 ### NoSQL
 | repository                     | run time | cron          |
 |:------------------------------:|:--------:|:-------------:|
-| mongodb-k8s-operator           | 12:50 AM | `50 00 * * *` |
-| mongodb-operator               | 1:00 AM  | `00 01 * * *` |
-| mongos-operator                | 4:30 AM  | `30 04 * * *` |
-| opensearch-k8s-operator        | 1:30 AM  | `30 01 * * *` |
-| opensearch-operator            | 1:40 AM  | `40 01 * * *` |
-| opensearch-dashboards-operator | 4:20 AM  | `20 04 * * *` |
-| redis-k8s-operator             | 1:10 AM  | `10 01 * * *` |
-| redis-operator                 | 1:20 AM  | `20 01 * * *` |
+| mongodb-k8s-operator           | 01:40 AM | `40 01 * * *` |
+| mongodb-operator               | 01:50 AM | `50 01 * * *` |
+| mongos-operator                | 02:00 AM | `00 02 * * *` |
+| opensearch-k8s-operator        | 02:10 AM | `10 02 * * *` |
+| opensearch-operator            | 02:20 AM | `20 02 * * *` |
+| opensearch-dashboards-operator | 02:30 AM | `30 02 * * *` |
+| redis-k8s-operator             | 02:40 AM | `40 02 * * *` |
+| redis-operator                 | 02:50 AM | `50 02 * * *` |
 
 ### Big Data
 | repository                        | run time | cron          |
 |:---------------------------------:|:--------:|:-------------:|
-| kafka-k8s-operator                | 1:50 AM  | `50 01 * * *` |
-| kafka-operator                    | 2:00 AM  | `00 02 * * *` |
-| kafka-test-app                    | 2:50 AM  | `50 02 * * *` |
-| zookeeper-k8s-operator            | 4:00 AM  | `00 04 * * *` |
-| zookeeper-operator                | 4:10 AM  | `10 04 * * *` |
-| spark-history-server-k8s-operator | 2:10 AM  | `10 02 * * *` |
-| spark-client-snap                 | 4:40 AM  | `40 04 * * *` |
+| kafka-k8s-operator                | 03:00 AM | `00 03 * * *` |
+| kafka-operator                    | 03:10 AM | `10 03 * * *` |
+| kafka-test-app                    | 03:20 AM | `20 03 * * *` |
+| zookeeper-k8s-operator            | 03:30 AM | `30 03 * * *` |
+| zookeeper-operator                | 03:40 AM | `40 03 * * *` |
+| spark-history-server-k8s-operator | 03:50 AM | `50 03 * * *` |
+| spark-client-snap                 | 04:00 AM | `00 04 * * *` |
 
 ### Other
 | repository         | run time | cron          |
 |:------------------:|:--------:|:-------------:|
-| data-integrator    | 2:20 AM  | `20 02 * * *` |
-| s3-integrator      | 2:30 AM  | `30 02 * * *` |
-| data-platform-libs | 2:40 AM  | `40 02 * * *` |
+| data-integrator    | 04:10 AM | `10 04 * * *` |
+| s3-integrator      | 04:20 AM | `20 04 * * *` |
+| data-platform-libs | 04:30 AM | `30 04 * * *` |

--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -28,7 +28,6 @@ jobs:
     secrets:
       discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
       discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
-      github_token: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write  # Needed to login to Discourse
       pull-requests: write  # Needed to create PR

--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -27,7 +27,7 @@ jobs:
       discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
       discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
     permissions:
-      contents: write  # Needed to create commits with Discourse content and update tags
+      contents: write  # Needed to push branch & tag
       pull-requests: write  # Needed to create PR
 ```
 

--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -21,13 +21,13 @@ on:
 
 jobs:
   sync-docs:
-    name: Sync docs from discourse
+    name: Sync docs from Discourse
     uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@v0.0.0
     secrets:
       discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
       discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
     permissions:
-      contents: write  # Needed to login to Discourse
+      contents: write  # Needed to create commits with Discourse content and update tags
       pull-requests: write  # Needed to create PR
 ```
 

--- a/.github/workflows/_sync_docs.yaml
+++ b/.github/workflows/_sync_docs.yaml
@@ -12,6 +12,7 @@ jobs:
   sync-docs:
     name: Sync discourse docs
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/_sync_docs.yaml
+++ b/.github/workflows/_sync_docs.yaml
@@ -10,11 +10,11 @@ on:
 
 jobs:
   sync-docs:
-    name: Open PR with docs changes
+    name: Sync discourse docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Open PR with docs changes
+      - name: Open PR with changes to discourse topics
         uses: deusebio/discourse-gatekeeper@c8adb89ea1cbceca54d78da798658373615487ac
         id: docs-pr
         with:

--- a/.github/workflows/_sync_docs.yaml
+++ b/.github/workflows/_sync_docs.yaml
@@ -10,13 +10,13 @@ on:
 
 jobs:
   sync-docs:
-    name: Sync discourse docs
+    name: Sync Discourse docs
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Open PR with changes to discourse topics
+      - name: Open PR with changes to Discourse topics
         uses: deusebio/discourse-gatekeeper@c8adb89ea1cbceca54d78da798658373615487ac
         id: docs-pr
         with:

--- a/.github/workflows/_sync_docs.yaml
+++ b/.github/workflows/_sync_docs.yaml
@@ -13,7 +13,8 @@ jobs:
     name: Sync discourse docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Open PR with changes to discourse topics
         uses: deusebio/discourse-gatekeeper@c8adb89ea1cbceca54d78da798658373615487ac
         id: docs-pr

--- a/.github/workflows/_sync_docs.yaml
+++ b/.github/workflows/_sync_docs.yaml
@@ -1,0 +1,29 @@
+on:
+  workflow_call:
+    secrets:
+      discourse-api-user:
+        description: Discourse API username
+        required: true
+      discourse-api-key:
+        description: Discourse API key
+        required: true
+
+jobs:
+  sync-docs:
+    name: Open PR with docs changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Open PR with docs changes
+        uses: deusebio/discourse-gatekeeper@c8adb89ea1cbceca54d78da798658373615487ac
+        id: docs-pr
+        with:
+          discourse_host: discourse.charmhub.io
+          discourse_api_username: ${{ secrets.discourse-api-user }}
+          discourse_api_key: ${{ secrets.discourse-api-key }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: "true"
+      - name: Show migrate output
+        run: echo '${{ steps.docs-pr.outputs.migrate }}'
+      - name: Show reconcile output
+        run: echo '${{ steps.docs-pr.outputs.reconcile }}'

--- a/.github/workflows/sync_docs.md
+++ b/.github/workflows/sync_docs.md
@@ -1,0 +1,72 @@
+Workflow file: [_sync_docs.yaml](_sync_docs.yaml)
+
+## Usage
+Add `.yaml` file to `.github/workflows/`
+```yaml
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Sync docs from Discourse
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: # Refer to Run schedule below
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-docs:
+    name: Open PR with docs changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Needed to login to Discourse
+      pull-requests: write # Needed to create PR
+    steps:
+      - uses: actions/checkout@v3
+      - name: Open PR with docs changes
+        uses: deusebio/discourse-gatekeeper@c8adb89ea1cbceca54d78da798658373615487ac
+        id: docs-pr
+        with:
+          discourse_host: discourse.charmhub.io
+          discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
+          discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: "true"
+      - name: Show migrate output
+        run: echo '${{ steps.docs-pr.outputs.migrate }}'
+      - name: Show reconcile output
+        run: echo '${{ steps.docs-pr.outputs.reconcile }}'
+```
+## Run schedule
+
+|             repository            |   run time  |     cron      |
+|:---------------------------------:|:-----------:|:-------------:|
+| mysql-k8s-operator                | 12:10:00 AM | `10 00 * * *` |
+| mysql-operator                    | 12:20:00 AM | `20 00 * * *` |
+| postgresql-k8s-operator           | 12:30:00 AM | `30 00 * * *` |
+| postgresql-operator               | 12:40:00 AM | `40 00 * * *` |
+| mongodb-k8s-operator              | 12:50:00 AM | `50 00 * * *` |
+| mongodb-operator                  |  1:00:00 AM | `00 01 * * *` |
+| redis-k8s-operator                |  1:10:00 AM | `10 01 * * *` |
+| redis-operator                    |  1:20:00 AM | `20 01 * * *` |
+| opensearch-k8s-operator           |  1:30:00 AM | `30 01 * * *` |
+| opensearch-operator               |  1:40:00 AM | `40 01 * * *` |
+| kafka-k8s-operator                |  1:50:00 AM | `50 01 * * *` |
+| kafka-operator                    |  2:00:00 AM | `00 02 * * *` |
+| spark-history-server-k8s-operator |  2:10:00 AM | `10 02 * * *` |
+| data-integrator                   |  2:20:00 AM | `20 02 * * *` |
+| s3-integrator                     |  2:30:00 AM | `30 02 * * *` |
+| data-platform-libs                |  2:40:00 AM | `40 02 * * *` |
+| kafka-test-app                    |  2:50:00 AM | `50 02 * * *` |
+| mysql-test-app                    |  3:00:00 AM | `00 03 * * *` |
+| postgresql-test-app               |  3:10:00 AM | `10 03 * * *` |
+| mysql-router-k8s-operator         |  3:20:00 AM | `20 03 * * *` |
+| mysql-router-operator             |  3:30:00 AM | `30 03 * * *` |
+| pgbouncer-k8s-operator            |  3:40:00 AM | `40 03 * * *` |
+| pgbouncer-operator                |  3:50:00 AM | `50 03 * * *` |
+| zookeeper-k8s-operator            |  4:00:00 AM | `00 04 * * *` |
+| zookeeper-operator                |  4:10:00 AM | `10 04 * * *` |
+| opensearch-dashboards-operator    |  4:20:00 AM | `20 04 * * *` |
+| mongos-operator                   |  4:30:00 AM | `30 04 * * *` |
+| spark-client-snap                 |  4:40:00 AM | `40 04 * * *` |

--- a/.github/workflows/sync_docs.md
+++ b/.github/workflows/sync_docs.md
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Open PR with docs changes
-        uses: deusebio/discourse-gatekeeper@c8adb89ea1cbceca54d78da798658373615487ac
+        uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml
         id: docs-pr
         with:
           discourse_host: discourse.charmhub.io

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | [release_charm.yaml](.github/workflows/release_charm.md)                   | Release charm to Charmhub                                                  |
 | [update_bundle.yaml](.github/workflows/update_bundle.md)                   | Update charm revisions in bundle                                           |
 | [sync_issue_to_jira.yaml](.github/workflows/sync_issue_to_jira.md)         | Sync GitHub issues to Jira issues                                          |
-| [_sync_docs.yaml](.github/workflows/sync_docs.md)                          | **Experimental** Sync Discourse documentation to GitHub                    |
+| [_sync_docs.yaml](.github/workflows/_sync_docs.md)                         | **Experimental** Sync Discourse documentation to GitHub                    |
 
 ### Version
 Recommendation: pin the latest version (e.g. `v1.0.0`) and use [Renovate](https://docs.renovatebot.com/) to stay up-to-date.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | [release_charm.yaml](.github/workflows/release_charm.md)                   | Release charm to Charmhub                                                  |
 | [update_bundle.yaml](.github/workflows/update_bundle.md)                   | Update charm revisions in bundle                                           |
 | [sync_issue_to_jira.yaml](.github/workflows/sync_issue_to_jira.md)         | Sync GitHub issues to Jira issues                                          |
-| [_sync_docs.yaml](.github/workflows/sync_docs.md)                          | Sync Discourse documentation to GitHub (experimental)                      |
+| [_sync_docs.yaml](.github/workflows/sync_docs.md)                          | **Experimental** Sync Discourse documentation to GitHub                    |
 
 ### Version
 Recommendation: pin the latest version (e.g. `v1.0.0`) and use [Renovate](https://docs.renovatebot.com/) to stay up-to-date.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | [release_charm.yaml](.github/workflows/release_charm.md)                   | Release charm to Charmhub                                                  |
 | [update_bundle.yaml](.github/workflows/update_bundle.md)                   | Update charm revisions in bundle                                           |
 | [sync_issue_to_jira.yaml](.github/workflows/sync_issue_to_jira.md)         | Sync GitHub issues to Jira issues                                          |
+| [_sync_docs.yaml](.github/workflows/sync_docs.md)                          | Sync Discourse documentation to GitHub (experimental)                      |
 
 ### Version
 Recommendation: pin the latest version (e.g. `v1.0.0`) and use [Renovate](https://docs.renovatebot.com/) to stay up-to-date.


### PR DESCRIPTION
[DPE-3641](https://warthogs.atlassian.net/browse/DPE-3641): Add discourse-gatekeeper to data-platform-workflows.

## Description
Adding `sync-docs.yaml` workflow that uses discourse-gatekeeper action to sync discourse docs to its corresponding GitHub repository.
- described by [`deusebio/discourse-gatekeeper/readme.md`](https://github.com/deusebio/discourse-gatekeeper/blob/c8adb89ea1cbceca54d78da798658373615487ac/README.md)
- sample usage in [`mysql-operator/.../sync_docs.yaml`](https://github.com/canonical/mysql-operator/blob/c7e57c086055aef58bb887f1b581cba27fb60af1/.github/workflows/sync_docs.yaml)

## Changes
- New file: `_sync_docs.yaml`
- New file: `sync_docs.md`
- Update: README.md

[DPE-3641]: https://warthogs.atlassian.net/browse/DPE-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ