### PR TITLE
compatible(pytest_plugins/microceph): Remove upper limit on pytest dependency

### DIFF
--- a/python/pytest_plugins/microceph/pyproject.toml
+++ b/python/pytest_plugins/microceph/pyproject.toml
@@ -15,8 +15,8 @@ microceph = "pytest_microceph._plugin"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pytest = "^7.4.4"
-boto3 = "^1.34.16"
+pytest = "*"
+boto3 = "*"
 
 
 [build-system]


### PR DESCRIPTION
https://python-poetry.org/docs/faq/#are-unbound-version-constraints-a-bad-idea

example of issue: https://github.com/canonical/mysql-operator/pull/424#issuecomment-2017077491