### PR TITLE
patch(integration_test_charm.yaml): Update secret docs to avoid redacting `{` and `}` from logs

### DIFF
--- a/.github/workflows/integration_test_charm.md
+++ b/.github/workflows/integration_test_charm.md
@@ -94,11 +94,11 @@ jobs:
     with:
       # ...
     secrets:
+      # GitHub appears to redact each line of a multi-line secret
+      # Avoid putting `{` or `}` on a line by itself so that it doesn't get redacted in logs
       integration-test: |
-        {
-          "AWS_ACCESS_KEY_ID": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-          "AWS_SECRET_ACCESS_KEY": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-        }
+        { "AWS_ACCESS_KEY_ID": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+          "AWS_SECRET_ACCESS_KEY": "${{ secrets.AWS_SECRET_ACCESS_KEY }}", }
 ```
 
 Python code to verify the string format:


### PR DESCRIPTION
Tested on https://github.com/canonical/opensearch-operator/pull/235

If `{` is on its own line, it gets redacted from logs
By moving `{` to a line with one of the secrets, `{` no longer gets redacted from logs