### PR TITLE
patch(pytest_plugins/microceph): Add retry if microceph not ready

### DIFF
--- a/python/pytest_plugins/microceph/pytest_microceph/_plugin.py
+++ b/python/pytest_plugins/microceph/pytest_microceph/_plugin.py
@@ -57,7 +57,7 @@ def microceph():
             if attempt == 2:
                 raise
             # microceph is not ready yet
-            logger.debug("Unable to connect to microceph via S3. Retrying")
+            logger.info("Unable to connect to microceph via S3. Retrying")
             time.sleep(1)
         else:
             break


### PR DESCRIPTION
Fixes #171 (on self-hosted runners, microceph is not ready before we create bucket)