### PR TITLE
patch(integration_test_charm.yaml): Skip Allure if test collection fails

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -393,8 +393,11 @@ jobs:
   allure-report:
     # TODO future improvement: use concurrency group for job
     name: (beta) Publish Allure report
-    if: ${{ !cancelled() && inputs._beta_allure_report && github.event_name == 'schedule' && github.run_attempt == '1'}}
+    # If `collect-integration-tests` fails, uploading an empty Allure report will clear the history
+    # for the next report (which we want to avoid)
+    if: ${{ !cancelled() && needs.collect-integration-tests.result == 'success' && inputs._beta_allure_report && github.event_name == 'schedule' && github.run_attempt == '1'}}
     needs:
+      - collect-integration-tests
       - integration-test
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
If `collect-integration-tests` fails, the Allure report will be empty

This will cause the next report to lose history of the previous reports

For example:
Before failure: https://canonical.github.io/mysql-operator/2536/ Failure: https://canonical.github.io/mysql-operator/2538/ After failure: https://canonical.github.io/mysql-operator/2543/