### PR TITLE
patch(_sync_docs.yaml): Remove on `push` from usage docs

### DIFF
--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -15,9 +15,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: # Refer to Run schedule below
-  push:
-    branches:
-      - main
 
 jobs:
   sync-docs:


### PR DESCRIPTION
Sync from GitHub -> Discourse is currently disabled; no need to sync on `push` for now

https://github.com/canonical/postgresql-k8s-operator/pull/495#discussion_r1626215631