### PR TITLE
patch: workaround pytest-asyncio issue

### DIFF
--- a/python/pytest_plugins/pytest_operator_groups/pytest_operator_groups/_plugin.py
+++ b/python/pytest_plugins/pytest_operator_groups/pytest_operator_groups/_plugin.py
@@ -45,7 +45,10 @@ def _get_group_id(function) -> typing.Optional[str]:
     ]
     if not group_markers:
         return
-    assert len(group_markers) == 1
+    # FIXME: pytest-asyncio-0.27.3 duplicates markers, making this assertion fail
+    # it's generally safe to ignore this assertion since no test should have more than one group marker
+    # ref: https://github.com/pytest-dev/pytest-asyncio/issues/813
+    # assert len(group_markers) == 1
     marker_args = group_markers[0].args
     assert len(marker_args) == 1
     group_id = marker_args[0]
@@ -89,7 +92,7 @@ def _get_runner(function) -> typing.Optional[_Runner]:
         else:
             return tuple(runner)
     raise TypeError(
-        f"`pytest.mark.runner(runs_on)` must be str, tuple[str], or list[str]"
+        "`pytest.mark.runner(runs_on)` must be str, tuple[str], or list[str]"
     )
 
 


### PR DESCRIPTION
**Issue**

pytest-asyncio 0.27.3 is [duplication function markers](https://github.com/pytest-dev/pytest-asyncio/issues/813), breaking tests group collection, that are asserting for one group marker per test.
This could be also be fixed by pinning pytest-asyncio to ^0.21.1 on charms, but IMO it's better suited do it here, since avoid pinning on multiple repositories.