### PR TITLE
patch: Install python3-pip with `--no-install-recommends`

### DIFF
--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -91,7 +91,8 @@ jobs:
         if: ${{ matrix.base.runner == 'Ubuntu_ARM64_4C_16G_01' }}
         run: |
           sudo apt-get update
-          sudo apt-get install python3-pip python3-venv -y
+          # python3-pip recommends build-essential—a relatively large package we don't need
+          sudo apt-get install python3-pip python3-venv -y --no-install-recommends
           python3 -m pip install pipx
           python3 -m pipx ensurepath
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/build_rock.yaml
+++ b/.github/workflows/build_rock.yaml
@@ -68,7 +68,8 @@ jobs:
         if: ${{ matrix.base.runner == 'Ubuntu_ARM64_4C_16G_01' }}
         run: |
           sudo apt-get update
-          sudo apt-get install python3-pip python3-venv -y
+          # python3-pip recommends build-essential—a relatively large package we don't need
+          sudo apt-get install python3-pip python3-venv -y --no-install-recommends
           python3 -m pip install pipx
           python3 -m pipx ensurepath
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -71,7 +71,8 @@ jobs:
         if: ${{ matrix.base.runner == 'Ubuntu_ARM64_4C_16G_01' }}
         run: |
           sudo apt-get update
-          sudo apt-get install python3-pip python3-venv -y
+          # python3-pip recommends build-essential—a relatively large package we don't need
+          sudo apt-get install python3-pip python3-venv -y --no-install-recommends
           python3 -m pip install pipx
           python3 -m pipx ensurepath
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -216,7 +216,8 @@ jobs:
         if: ${{ inputs.architecture == 'arm64' || matrix.groups.self_hosted }}
         run: |
           sudo apt-get update
-          sudo apt-get install python3-pip python3-venv -y
+          # python3-pip recommends build-essential—a relatively large package we don't need
+          sudo apt-get install python3-pip python3-venv -y --no-install-recommends
           python3 -m pip install --user pipx
           python3 -m pipx ensurepath
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
python3-pip recommends build-essential, which is a relatively large package we don't need