### PR TITLE
patch(_sync_docs.yaml): Updated secret keys in usage docs

### DIFF
--- a/.github/workflows/_sync_docs.md
+++ b/.github/workflows/_sync_docs.md
@@ -21,8 +21,8 @@ jobs:
     name: Sync docs from Discourse
     uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@v0.0.0
     secrets:
-      discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
-      discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
+      discourse-api-user: ${{ secrets.DISCOURSE_API_USERNAME }}
+      discourse-api-key: ${{ secrets.DISCOURSE_API_KEY }}
     permissions:
       contents: write  # Needed to push branch & tag
       pull-requests: write  # Needed to create PR


### PR DESCRIPTION
The `_sync_docs.md` workflow example was using incorrect keys to make the workflow call.

Solved by updating the keys to the correct ones.