### PR TITLE
patch(integration_test_charm.yaml): Display status and logs from multiple models

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -412,21 +412,49 @@ jobs:
       - name: juju status
         timeout-minutes: 1
         if: ${{ success() || (failure() && steps.tests.outcome == 'failure') }}
-        run: juju status --color --relations | tee ~/logs/juju-status.txt
+        run: |
+          FILE=~/logs/juju-status.txt
+          MODELS=$(juju models --format json | jq -r '.models.[] | select(."short-name" != "controller") | ."short-name"' | sed ':a;N;$!ba;s/\n/ /g')
+          for MODEL in $MODELS
+          do
+            if [ -f $FILE ]; then
+              echo "\n" | tee -a $FILE
+            fi
+            juju status --model=$MODEL --color --relations | tee -a $FILE
+          done
       - name: juju debug-log
         timeout-minutes: 3
         if: ${{ success() || (failure() && steps.tests.outcome == 'failure') }}
         # TODO future improvement: show models/ logs in juju-debug-log.txt to match `juju debug-log`
         run: |
+          FILE=~/logs/juju-debug-log.txt
+          MODELS=$(juju models --format json | jq -r '.models.[] | select(."short-name" != "controller") | ."short-name"' | sed ':a;N;$!ba;s/\n/ /g')
           if [[ '${{ inputs.cloud }}' == 'lxd' ]]
           then
             mkdir ~/logs/models/
             juju scp --model controller 0:/var/log/juju/models/* ~/logs/models/
             juju scp --model controller 0:/var/log/juju/logsink.log ~/logs/controller-logsink.log
-            convert-logsink-to-debug-log ~/logs/controller-logsink.log ~/logs/juju-debug-log.txt
-            cat ~/logs/juju-debug-log.txt
+            ORIGINAL_MODEL=$(juju switch)
+            for MODEL in $MODELS
+            do
+              juju switch $MODEL
+              if [ -f $FILE ]; then
+                echo "\n" | tee -a $FILE
+              fi
+              echo "Model: $MODEL" | tee -a $FILE
+              convert-logsink-to-debug-log ~/logs/controller-logsink.log $FILE
+            done
+            juju switch $ORIGINAL_MODEL
+            cat $FILE
           else
-            juju debug-log --color --replay --no-tail | tee ~/logs/juju-debug-log.txt
+            for MODEL in $MODELS
+            do
+              if [ -f $FILE ]; then
+                echo "\n" | tee -a $FILE
+              fi
+              echo "Model: $MODEL" | tee -a $FILE
+              juju debug-log --model=$MODEL --color --replay --no-tail | tee -a $FILE
+            done
           fi
       - name: Upload logs
         timeout-minutes: 5

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -418,9 +418,9 @@ jobs:
           for MODEL in $MODELS
           do
             if [ -f $FILE ]; then
-              echo "\n" | tee -a $FILE
+              printf "\n" | tee -a $FILE
             fi
-            juju status --model=$MODEL --color --relations | tee -a $FILE
+            juju status --model="$MODEL" --color --relations | tee -a $FILE
           done
       - name: juju debug-log
         timeout-minutes: 3
@@ -437,23 +437,23 @@ jobs:
             ORIGINAL_MODEL=$(juju switch)
             for MODEL in $MODELS
             do
-              juju switch $MODEL
+              juju switch "$MODEL"
               if [ -f $FILE ]; then
-                echo "\n" | tee -a $FILE
+                printf "\n" | tee -a $FILE
               fi
-              echo "Model: $MODEL" | tee -a $FILE
+              printf "Model: %s\n" "$MODEL" | tee -a $FILE
               convert-logsink-to-debug-log ~/logs/controller-logsink.log $FILE
             done
-            juju switch $ORIGINAL_MODEL
+            juju switch "$ORIGINAL_MODEL"
             cat $FILE
           else
             for MODEL in $MODELS
             do
               if [ -f $FILE ]; then
-                echo "\n" | tee -a $FILE
+                printf "\n" | tee -a $FILE
               fi
-              echo "Model: $MODEL" | tee -a $FILE
-              juju debug-log --model=$MODEL --color --replay --no-tail | tee -a $FILE
+              printf "Model: %s\n" "$MODEL" | tee -a $FILE
+              juju debug-log --model="$MODEL" --color --replay --no-tail | tee -a $FILE
             done
           fi
       - name: Upload logs

--- a/python/cli/data_platform_workflows_cli/convert_logsink_to_debug_log.py
+++ b/python/cli/data_platform_workflows_cli/convert_logsink_to_debug_log.py
@@ -33,16 +33,16 @@ def main():
     args = parser.parse_args()
     logsink = pathlib.Path(args.logsink_file).expanduser()
     output = pathlib.Path(args.output_file).expanduser()
-    model = json.loads(
+    model = next(iter(json.loads(
         subprocess.run(
             ["juju", "show-model", "--format", "json"],
             capture_output=True,
             check=True,
             encoding="utf-8",
         ).stdout
-    )["test"]["model-uuid"]
+    ).values()))["model-uuid"]
     with logsink.open("r", encoding="utf-8") as logsink_file, output.open(
-        "w", encoding="utf-8"
+        "a", encoding="utf-8"
     ) as output_file:
         # `skip` used for multi-line log messages
         skip = False


### PR DESCRIPTION
## Issue
For integration tests like the one for async replication, it would be helpful to have status and logs from multiple models.

## Solution
In `.github/workflows/integration_test_charm.yaml`:

* Loop over the existing models (except the `controller` model) and run the `juju status` and `juju debug-log` (or `convert-logsink-to-debug-log` for LXD clouds) commands for each model, appending the output to the status and the log files, respectively.

* For the logs, write the model name before writing the logs to the logs file.

In `python/cli/data_platform_workflows_cli/convert_logsink_to_debug_log.py`:

* Get the first model from the `juju show-model` command output because a second model has a name different from the test (example: `test-other` in the PostgreSQL charms async replication integration tests).

* Append the logs to the already existing log file to support logs from multiple models.

Fixes https://github.com/canonical/data-platform-workflows/issues/193.