### PR TITLE
breaking(integration_test_charm.yaml): Run arm64 tests on all events

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -107,11 +107,6 @@ jobs:
     # (In the UI, when this workflow is called with a matrix, GitHub will separate each matrix
     # combination and preserve job ordering within a matrix combination.)
     name: ${{ inputs.juju-agent-version || inputs.juju-snap-channel }} | ${{ inputs.architecture }} | Collect integration test groups
-    # Only run arm64 integration tests on `schedule`
-    # Temporary solution to decrease costs (of GitHub hosted arm64 runners) while IS hosted arm64 runners are unstable.
-    # Context: https://chat.canonical.com/canonical/channels/actions-incident
-    # TODO: remove (since we're using Azure-hosted runners now)
-    if: ${{ inputs.architecture == 'amd64' || (inputs.architecture == 'arm64' && github.event_name == 'schedule' && github.run_attempt == '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
This reverts commit 59afebbf (#188)

Run tests on pull request, release, and schedule instead of only on schedule