### PR TITLE
breaking(release_charm.yaml): Upload OCI resources from GHCR directly

### DIFF
--- a/python/cli/data_platform_workflows_cli/craft_tools/release.py
+++ b/python/cli/data_platform_workflows_cli/craft_tools/release.py
@@ -176,7 +176,7 @@ def charm():
                 charm_name,
                 resource_name,
                 "--image",
-                resource["upstream-source"],
+                f'docker://{resource["upstream-source"]}',
             ]
         )
         revision: int = json.loads(output)["revision"]


### PR DESCRIPTION
charmcraft 2.7.0 contains a fix for multi-arch OCI images issue: https://github.com/canonical/charmcraft/issues/1685 fix: https://github.com/canonical/charmcraft/pull/1708

However, it fixes it in a "backwards-compatible" way—if the image is available locally, it will still upload it incorrectly.

Stop downloading the image locally & always use GHCR so that charmcraft uploads the image correctly

This will break on charmcraft < 2.7.0