### PR TITLE
patch(_sync_docs.yaml): Update source of gatekeeper action

### DIFF
--- a/.github/workflows/_sync_docs.yaml
+++ b/.github/workflows/_sync_docs.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Open PR with changes to Discourse topics
-        uses: deusebio/discourse-gatekeeper@c8adb89ea1cbceca54d78da798658373615487ac
+        uses: canonical/discourse-gatekeeper@main
         id: docs-pr
         with:
           discourse_host: discourse.charmhub.io


### PR DESCRIPTION
## Issue
The `_sync_docs.yaml` workflow was using a fork instead of the official canonical repository for the discourse-gatekeeper action.

The canonical action no longer has the limitations that prompted using the fork.

## Solution
Changed the repository of the action to `canonical/discourse-gatekeeper@main`

**Note:** Using `@main` instead of their recommended `@stable` because those branches have diverged for unknown reasons, and `@main` seems to have some fixes that we need.