### PR TITLE
compatible(build_charm.yaml): Add GitHub auth to avoid ccc rate limit

### DIFF
--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -152,6 +152,9 @@ jobs:
         id: pack
         working-directory: ${{ inputs.path-to-charm-directory }}
         run: sg lxd -c "${{ steps.pack-command.outputs.command }}"
+        env:
+          # Used by charmcraftcache (to avoid GitHub API rate limit)
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload charmcraft logs
         if: ${{ failure() && steps.pack.outcome == 'failure' }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Avoid charmcraftcache failing due to GitHub API rate limit by authenticating to GitHub