### PR TITLE
patch(integration_test_charm.yaml): Shorten recommended job name

### DIFF
--- a/.github/workflows/integration_test_charm.md
+++ b/.github/workflows/integration_test_charm.md
@@ -13,7 +13,7 @@ jobs:
       cache: true
 
   integration-test:
-    name: Integration test charm
+    name: Integration
     needs:
       - build
     uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v0.0.0

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -201,7 +201,7 @@ jobs:
         # if spot instance evicted by Azure
         run: |
           mkdir ~/dpw/
-          echo 'Integration test charm | ${{ inputs.juju-agent-version || inputs.juju-snap-channel }} | ${{ inputs.architecture }} / ${{ matrix.groups.job_name }}' > ~/dpw/job_name
+          echo 'Integration | ${{ inputs.juju-agent-version || inputs.juju-snap-channel }} | ${{ inputs.architecture }} / ${{ matrix.groups.job_name }}' > ~/dpw/job_name
       - name: (GitHub hosted) Free up disk space
         timeout-minutes: 1
         # If not (IS hosted or Data Platform hosted)


### PR DESCRIPTION
So that matrix values (e.g. juju version, arch) can show without truncating in GitHub Actions UI sidebar