### PR TITLE
compatible(integration_test_charm.yaml): Pre-download lxd image

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -373,7 +373,7 @@ jobs:
         run: |
           if [[ '${{ inputs.architecture }}' == 'amd64' ]]
           then
-            # shellcheck disable=SC2078
+            # shellcheck disable=SC2193
             # (shellcheck sees it as constant, but GitHub Actions expression is not constant between workflow runs)
             if [[ '${{ steps.parse-versions.outputs.snap_channel }}' == 2.* ]]
             then


### PR DESCRIPTION
Temporary workaround for slow image downloads (https://portal.admin.canonical.com/C164453)

Download LXD image separately so that we avoid juju bootstrap timeout if LXD image download is slow

Image fingerprint will need to be manually updated