### PR TITLE
patch(integration_test_charm.yaml): Remove `#` from Allure commit message

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -581,6 +581,6 @@ jobs:
           git add .
           git config user.name "GitHub Actions"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "Allure report #${{ github.run_number }}"
+          git commit -m "Allure report ${{ github.run_number }}"
           # Uses token set in checkout step
           git push origin gh-pages-beta


### PR DESCRIPTION
Currently, Allure commits are accidentally linking to pull requests