### PR TITLE
patch(build_snap.yaml): Increase timeout to 30 minutes

### DIFF
--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -65,7 +65,7 @@ jobs:
     needs:
       - collect-bases
     runs-on: ${{ matrix.base.runner }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: (GitHub-hosted ARM runner) Install pipx
         if: ${{ matrix.base.runner == 'Ubuntu_ARM64_4C_16G_01' }}


### PR DESCRIPTION
Seeing timeouts on postgresql snap on arm64
e.g. https://github.com/canonical/test-runners-data-platform/actions/runs/10055748441/job/27793885825?pr=2