### PR TITLE
breaking: Change default charmcraft version to 2.x

### DIFF
--- a/python/cli/data_platform_workflows_cli/parse_snap_version.py
+++ b/python/cli/data_platform_workflows_cli/parse_snap_version.py
@@ -17,6 +17,8 @@ def main():
         install_flag = f"'--revision={args.revision}'"
     elif args.channel:
         install_flag = f"'--channel={args.channel}'"
+    elif args.channel_input_name == "charmcraft-snap-channel":
+        install_flag = "'--channel=2.x/stable'"
     else:
         install_flag = None
     github_actions.output["install_flag"] = install_flag


### PR DESCRIPTION
charmcraft 3.1 releases arm64 charms on amd64

Temporary fix while charmcraft 3.1 is stabilized