### PR TITLE
compatible(integration_test_charm.yaml): Add `jhack tail` to logs

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -477,8 +477,6 @@ jobs:
         timeout-minutes: 3
         if: ${{ success() || (failure() && steps.tests.outcome == 'failure') }}
         run: tee-log-for-all-models --log-command 'juju debug-log --color --replay --no-tail' --log-file-name juju-debug-log.txt
-        env:
-          LOGLEVEL: DEBUG
       - name: jhack tail
         timeout-minutes: 3
         if: ${{ success() || (failure() && steps.tests.outcome == 'failure') }}


### PR DESCRIPTION
Reverts #224

Uses huge speed improvement from https://github.com/canonical/jhack/pull/175 —thank you @PietroPasotti!