### PR TITLE
patch(integration_test_charm.yaml): Capture tcpdump to debug GH artifacts issue

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -190,7 +190,7 @@ jobs:
     needs:
       - collect-integration-tests
     runs-on: ${{ matrix.groups.runner || fromJSON(needs.collect-integration-tests.outputs.default_runner) }}
-    timeout-minutes: 287  # Sum of steps `timeout-minutes` + 5
+    timeout-minutes: 308  # Sum of steps `timeout-minutes` + 5
     steps:
       - name: (Data Platform hosted) Write job name to file
         # Data Platform hosted
@@ -420,12 +420,39 @@ jobs:
         timeout-minutes: 3
         if: ${{ inputs.libjuju-version-constraint }}
         run: poetry add --lock --group integration juju@'${{ inputs.libjuju-version-constraint }}'
+      - name: (artifact debug) start tcpdump capture
+        timeout-minutes: 1
+        run: |
+          touch mycapturefile1.pcap 
+          sudo sysctl net.ipv4.ip_local_port_range 
+          sudo sysctl net.ipv4.tcp_fin_timeout
+
+          sudo sysctl net.ipv4.ip_local_port_range="15000 65000"
+          sudo sysctl net.ipv4.tcp_fin_timeout=120
+
+          sudo tcpdump -nn -i any -w mycapturefile1.cap port 443 &
       - name: Download packed charm(s)
+        id: download-charms
         timeout-minutes: 5
         uses: actions/download-artifact@v4
         with:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
+      - name: (artifact debug) stop tcpdump capture
+        timeout-minutes: 1
+        if: ${{ !cancelled() }}
+        run: |
+          sudo pkill tcpdump
+
+          sudo sysctl net.ipv4.ip_local_port_range
+          sudo sysctl net.ipv4.tcp_fin_timeout
+      - name: (artifact debug) upload tcpdump capture
+        timeout-minutes: 5
+        if: ${{ failure() && steps.download-charms.outcome == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: mycapturefile1.cap
+          path: mycapturefile1.cap
       - name: Select test stability level
         timeout-minutes: 1
         id: select-test-stability
@@ -461,7 +488,19 @@ jobs:
         run: sg '${{ steps.parse-cloud.outputs.group }}' -c "tox run -e integration -- '${{ matrix.groups.path_to_test_file }}' --group='${{ matrix.groups.group_id }}' -m '${{ steps.select-test-stability.outputs.mark_expression }}' --model test ${{ steps.allure-option.outputs.option }}"
         env:
           SECRETS_FROM_GITHUB: ${{ secrets.integration-test }}
+      - name: (artifact debug) start tcpdump capture
+        timeout-minutes: 1
+        run: |
+          touch mycapturefile2.pcap 
+          sudo sysctl net.ipv4.ip_local_port_range 
+          sudo sysctl net.ipv4.tcp_fin_timeout
+
+          sudo sysctl net.ipv4.ip_local_port_range="15000 65000"
+          sudo sysctl net.ipv4.tcp_fin_timeout=120
+
+          sudo tcpdump -nn -i any -w mycapturefile2.cap port 443 &
       - name: (beta) Upload Allure results
+        id: upload-allure
         timeout-minutes: 3
         if: ${{ (success() || (failure() && steps.tests.outcome == 'failure')) && inputs._beta_allure_report && github.event_name == 'schedule' && github.run_attempt == '1' }}
         uses: actions/upload-artifact@v4
@@ -469,6 +508,21 @@ jobs:
           name: allure-results-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || steps.parse-versions.outputs.snap_channel_for_artifact }}-${{ inputs.architecture }}-${{ matrix.groups.artifact_group_id }}
           path: allure-results/
           if-no-files-found: error
+      - name: (artifact debug) stop tcpdump capture
+        timeout-minutes: 1
+        if: ${{ !cancelled() }}
+        run: |
+          sudo pkill tcpdump
+
+          sudo sysctl net.ipv4.ip_local_port_range
+          sudo sysctl net.ipv4.tcp_fin_timeout
+      - name: (artifact debug) upload tcpdump capture
+        timeout-minutes: 5
+        if: ${{ failure() && steps.upload-allure.outcome == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: mycapturefile2.cap
+          path: mycapturefile2.cap
       - name: juju status
         timeout-minutes: 1
         if: ${{ success() || (failure() && steps.tests.outcome == 'failure') }}
@@ -481,7 +535,19 @@ jobs:
         timeout-minutes: 3
         if: ${{ success() || (failure() && steps.tests.outcome == 'failure') }}
         run: tee-log-for-all-models --log-command 'jhack tail --printer raw --replay --no-watch' --log-file-name jhack-tail.txt
+      - name: (artifact debug) start tcpdump capture
+        timeout-minutes: 1
+        run: |
+          touch mycapturefile3.pcap 
+          sudo sysctl net.ipv4.ip_local_port_range 
+          sudo sysctl net.ipv4.tcp_fin_timeout
+
+          sudo sysctl net.ipv4.ip_local_port_range="15000 65000"
+          sudo sysctl net.ipv4.tcp_fin_timeout=120
+
+          sudo tcpdump -nn -i any -w mycapturefile3.cap port 443 &
       - name: Upload logs
+        id: upload-logs
         timeout-minutes: 5
         if: ${{ success() || (failure() && steps.tests.outcome == 'failure') }}
         uses: actions/upload-artifact@v4
@@ -489,6 +555,21 @@ jobs:
           name: logs-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || steps.parse-versions.outputs.snap_channel_for_artifact }}-${{ inputs.architecture }}-${{ matrix.groups.artifact_group_id }}
           path: ~/logs/
           if-no-files-found: error
+      - name: (artifact debug) stop tcpdump capture
+        timeout-minutes: 1
+        if: ${{ !cancelled() }}
+        run: |
+          sudo pkill tcpdump
+
+          sudo sysctl net.ipv4.ip_local_port_range
+          sudo sysctl net.ipv4.tcp_fin_timeout
+      - name: (artifact debug) upload tcpdump capture
+        timeout-minutes: 5
+        if: ${{ failure() && steps.upload-logs.outcome == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: mycapturefile3.cap
+          path: mycapturefile3.cap
       - name: Disk usage
         timeout-minutes: 1
         if: ${{ success() || (failure() && steps.tests.outcome == 'failure') }}


### PR DESCRIPTION
GitHub artifacts v4 has intermittent issues:
https://github.com/actions/upload-artifact/issues/560#issuecomment-2178444482
https://github.com/actions/upload-artifact/issues/569#issuecomment-2188730144
https://github.com/actions/download-artifact/issues/338

Capture tcpdump as requested by GitHub Support