### PR TITLE
patch(build_*.yaml): Switch ARM runner image

### DIFF
--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -87,17 +87,8 @@ jobs:
     runs-on: ${{ matrix.base.runner }}
     timeout-minutes: 120
     steps:
-      - name: (GitHub-hosted ARM runner) Install pipx
-        if: ${{ matrix.base.runner == 'Ubuntu_ARM64_4C_16G_01' }}
-        run: |
-          sudo apt-get update
-          # python3-pip recommends build-essential—a relatively large package we don't need
-          sudo apt-get install python3-pip python3-venv -y --no-install-recommends
-          python3 -m pip install pipx
-          python3 -m pipx ensurepath
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: (GitHub-hosted ARM runner) Install libpq-dev
-        if: ${{ matrix.base.runner == 'Ubuntu_ARM64_4C_16G_01' }}
+        if: ${{ matrix.base.runner == 'Ubuntu_ARM64_4C_16G_02' }}
         # Needed for `charmcraftcache` to resolve dependencies (for postgresql charms with psycopg2)
         run: sudo apt-get install libpq-dev -y
       - name: Get workflow version

--- a/.github/workflows/build_rock.yaml
+++ b/.github/workflows/build_rock.yaml
@@ -64,15 +64,6 @@ jobs:
     runs-on: ${{ matrix.base.runner }}
     timeout-minutes: 15
     steps:
-      - name: (GitHub-hosted ARM runner) Install pipx
-        if: ${{ matrix.base.runner == 'Ubuntu_ARM64_4C_16G_01' }}
-        run: |
-          sudo apt-get update
-          # python3-pip recommends build-essential—a relatively large package we don't need
-          sudo apt-get install python3-pip python3-venv -y --no-install-recommends
-          python3 -m pip install pipx
-          python3 -m pipx ensurepath
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Get workflow version
         id: workflow-version
         uses: canonical/get-workflow-version-action@v1

--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -67,15 +67,6 @@ jobs:
     runs-on: ${{ matrix.base.runner }}
     timeout-minutes: 30
     steps:
-      - name: (GitHub-hosted ARM runner) Install pipx
-        if: ${{ matrix.base.runner == 'Ubuntu_ARM64_4C_16G_01' }}
-        run: |
-          sudo apt-get update
-          # python3-pip recommends build-essential—a relatively large package we don't need
-          sudo apt-get install python3-pip python3-venv -y --no-install-recommends
-          python3 -m pip install pipx
-          python3 -m pipx ensurepath
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Get workflow version
         id: workflow-version
         uses: canonical/get-workflow-version-action@v1

--- a/python/cli/data_platform_workflows_cli/craft_tools/collect_bases.py
+++ b/python/cli/data_platform_workflows_cli/craft_tools/collect_bases.py
@@ -24,7 +24,7 @@ from . import craft
 logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 RUNNERS = {
     craft.Architecture.X64: "ubuntu-latest",
-    craft.Architecture.ARM64: "Ubuntu_ARM64_4C_16G_01",
+    craft.Architecture.ARM64: "Ubuntu_ARM64_4C_16G_02",
 }
 
 


### PR DESCRIPTION
On September 3rd, the GitHub Ubuntu arm64 image will be removed. (https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/)

Switch to runner with "Ubuntu 22.04 by Arm Limited" image