### PR TITLE
patch(update_bundle.yaml): Add resource pinning of OCI images for bundles

### DIFF
--- a/python/cli/data_platform_workflows_cli/update_bundle.py
+++ b/python/cli/data_platform_workflows_cli/update_bundle.py
@@ -65,7 +65,7 @@ def fetch_oci_image_from_channel(charm, charm_channel) -> Optional[Dict[str,str]
     metadata = yaml.safe_load(default_release["revision"]["metadata-yaml"])
     for resource_name, resource_data in metadata.get("resources", {}).items():
         if resource_data.get("type") == "oci-image" and "upstream-source" in resource_data:
-            return {resource_name: resource_data["upstream_source"]}
+            return {resource_name: resource_data["upstream-source"]}
     return None
 
 

--- a/python/cli/data_platform_workflows_cli/update_bundle.py
+++ b/python/cli/data_platform_workflows_cli/update_bundle.py
@@ -12,7 +12,7 @@ import requests
 import yaml
 
 from . import github_actions
-from typing import Optional, Dict
+from typing import Optional, Dict, Tuple
 
 
 def get_ubuntu_version(series: str) -> str:
@@ -25,44 +25,39 @@ def get_ubuntu_version(series: str) -> str:
     ).stdout.split(" ")[0]
 
 
-def fetch_latest_revision(charm, charm_channel, series=None) -> int:
-    """Gets the latest charm revision number in channel."""
+def fetch_charm_info_from_store(charm, charm_channel) -> Tuple[Dict, Dict]:
+    """Returns, for a given channel, the necessary charm info from store endpoint."""
     response = requests.get(
-        f"https://api.snapcraft.io/v2/charms/info/{charm}?fields=channel-map"
+        f"https://api.snapcraft.io/v2/charms/info/{charm}?fields=channel-map,default-release&channel={charm_channel}"
     )
     response.raise_for_status()
     channel_map = response.json()["channel-map"]
-    track, risk = charm_channel.split("/")
+    metadata = yaml.safe_load(response.json()["default-release"]["revision"]["metadata-yaml"])
+    return channel_map, metadata
+
+
+def fetch_latest_revision(channel_map, series=None) -> int:
+    """Gets the latest charm revision number in channel."""
     revisions = []
     for channel in channel_map:
         if (
-            channel["channel"]["risk"] == risk
-            and channel["channel"]["track"] == track
-            and channel["channel"]["base"]["architecture"] == "amd64"
-        ):
-            if (
+            channel["channel"]["base"]["architecture"] == "amd64"
+            and (
                 series is None
                 or get_ubuntu_version(series) == channel["channel"]["base"]["channel"]
-            ):
-                revisions.append(channel["revision"]["revision"])
+            )
+        ):
+            revisions.append(channel["revision"]["revision"])
     if not revisions:
-        raise ValueError(
-            f"Revision not found for {charm} on {charm_channel} for Ubuntu {series}"
-        )
+        return None
     # If the charm supports multiple Ubuntu bases (and series=None), it's
     # possible that there is a different revision for each base.
     # Select the latest revision.
     return max(revisions)
 
 
-def fetch_oci_image_from_channel(charm, charm_channel) -> Optional[Dict[str,str]]:
-    """Gets the OCI image source from metadata.yaml of latest revision released in channel."""
-    response = requests.get(
-        f"https://api.snapcraft.io/v2/charms/info/{charm}?fields=default-release&channel={charm_channel}"
-    )
-    response.raise_for_status()
-    default_release = response.json()["default-release"]
-    metadata = yaml.safe_load(default_release["revision"]["metadata-yaml"])
+def fetch_oci_image_from_metadata(metadata) -> Optional[Dict[str,str]]:
+    """Gets the OCI image source from metadata.yaml."""
     for resource_name, resource_data in metadata.get("resources", {}).items():
         if resource_data.get("type") == "oci-image" and "upstream-source" in resource_data:
             return {resource_name: resource_data["upstream-source"]}
@@ -81,10 +76,15 @@ def main():
     # Full list of possible series config (unsupported) can be found under "Charm series" at https://juju.is/docs/olm/bundle
     default_series = file_data.get("series")
     for app in file_data["applications"].values():
-        app["revision"] = fetch_latest_revision(
-            app["charm"], app["channel"], app.get("series", default_series)
-        )
-        if oci_image := fetch_oci_image_from_channel(app["charm"], app["channel"]):
+        channel_map, metadata = fetch_charm_info_from_store(app['charm'], app['channel'])
+
+        if latest_revision := fetch_latest_revision(channel_map, app.get("series", default_series)):
+            app["revision"] = latest_revision
+        else:
+            raise ValueError(
+                f"Revision not found for {app['charm']} on {app['channel']} for Ubuntu {app.get('series', default_series)}"
+            )
+        if oci_image := fetch_oci_image_from_metadata(metadata):
             app["resources"] = oci_image
 
     with open(file_path, "w") as file:


### PR DESCRIPTION
UPDATE: Refactored this PR to take into account John Meinel's suggested formatting, see result here: https://github.com/canonical/postgresql-k8s-bundle/pull/212/files

Related ticket: https://warthogs.atlassian.net/browse/DPE-5381

This PR will make `update_bundle.yaml` include OCI image versions + resource revisions that correspond to each charm, as this is will be required information for airgapped deployments using the proxy store.

Note: As of now, the proxy store doesn't take into consideration the [charm revisions](https://warthogs.atlassian.net/browse/PF-5185) nor the [resource revisions](https://warthogs.atlassian.net/browse/PF-5369) like juju does, so this may be subjected to change in the future! We are including this in the bundle as preparation for those features. 

See more information about proxy store and airgapped deployments here: https://documentation.ubuntu.com/snap-store-proxy/en/airgap-charmhub