### PR TITLE
patch(_update_bundle.yaml): Hardcode snap channels for `charmed_postgresql` and `charmed_pgbouncer`

### DIFF
--- a/python/cli/data_platform_workflows_cli/update_bundle.py
+++ b/python/cli/data_platform_workflows_cli/update_bundle.py
@@ -158,7 +158,7 @@ def fetch_postgresql_snaps(charm_revision) -> list[Snap]:
             result.append(Snap(
                 name=snap_name,
                 revision=int(snap_info["revision"]["x86_64"]),
-                push_channel="14/stable",
+                push_channel="14/edge",
             ))
         return result
     else:
@@ -178,7 +178,7 @@ def fetch_pgbouncer_snaps(charm_revision) -> list[Snap]:
             result.append(Snap(
                 name=snap_name,
                 revision=int(snap_info["revision"]["x86_64"]),
-                push_channel="1/stable",
+                push_channel="1/edge",
             ))
         return result
     else:

--- a/python/cli/data_platform_workflows_cli/update_bundle.py
+++ b/python/cli/data_platform_workflows_cli/update_bundle.py
@@ -158,7 +158,7 @@ def fetch_postgresql_snaps(charm_revision) -> list[Snap]:
             result.append(Snap(
                 name=snap_name,
                 revision=int(snap_info["revision"]["x86_64"]),
-                push_channel=snap_info["channel"],
+                push_channel="14/stable",
             ))
         return result
     else:
@@ -178,7 +178,7 @@ def fetch_pgbouncer_snaps(charm_revision) -> list[Snap]:
             result.append(Snap(
                 name=snap_name,
                 revision=int(snap_info["revision"]["x86_64"]),
-                push_channel=snap_info["channel"],
+                push_channel="1/stable",
             ))
         return result
     else:


### PR DESCRIPTION
With the merge of https://github.com/canonical/postgresql-operator/pull/638 and https://github.com/canonical/pgbouncer-operator/pull/384, the workflow cannot rely on charm's source code to fetch the snap channel info.