### PR TITLE
patch(_update_bundle.yaml): Alphabetically sort snap revision list

### DIFF
--- a/python/cli/data_platform_workflows_cli/update_bundle.py
+++ b/python/cli/data_platform_workflows_cli/update_bundle.py
@@ -16,7 +16,7 @@ import yaml
 from . import github_actions
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(order=True, frozen=True)
 class Snap:
     name: str
     revision: int
@@ -272,8 +272,7 @@ def main():
             file.write(yaml_string)
 
     if len(bundle_snaps) > 0:
-        packages = [dataclasses.asdict(snap) for snap in bundle_snaps]
-        snaps_data = {"packages": sorted(packages, key=lambda x: (x['name'], x['revision']))}
+        snaps_data = {"packages": [dataclasses.asdict(snap) for snap in sorted(bundle_snaps)]}
         try:
             old_snaps_data = yaml.safe_load(pathlib.Path(SNAPS_YAML_PATH).read_text())
         except FileNotFoundError:

--- a/python/cli/data_platform_workflows_cli/update_bundle.py
+++ b/python/cli/data_platform_workflows_cli/update_bundle.py
@@ -272,17 +272,16 @@ def main():
             file.write(yaml_string)
 
     if len(bundle_snaps) > 0:
-        snaps_data = {"packages": [dataclasses.asdict(snap) for snap in bundle_snaps]}
+        packages = [dataclasses.asdict(snap) for snap in bundle_snaps]
+        snaps_data = {"packages": sorted(packages, key=lambda x: x['name'])}
         try:
             old_snaps_data = yaml.safe_load(pathlib.Path(SNAPS_YAML_PATH).read_text())
         except FileNotFoundError:
             old_snaps_data = {}
 
         if old_snaps_data != snaps_data:
-            print(old_snaps_data)
-            print(snaps_data)
             updates_available = True
             with open(SNAPS_YAML_PATH, "w") as file:
-                yaml.dump(snaps_data, file, sort_keys=True)
+                yaml.dump(snaps_data, file)
 
     github_actions.output["updates_available"] = json.dumps(updates_available)

--- a/python/cli/data_platform_workflows_cli/update_bundle.py
+++ b/python/cli/data_platform_workflows_cli/update_bundle.py
@@ -273,7 +273,7 @@ def main():
 
     if len(bundle_snaps) > 0:
         packages = [dataclasses.asdict(snap) for snap in bundle_snaps]
-        snaps_data = {"packages": sorted(packages, key=lambda x: x['name'])}
+        snaps_data = {"packages": sorted(packages, key=lambda x: (x['name'], x['revision']))}
         try:
             old_snaps_data = yaml.safe_load(pathlib.Path(SNAPS_YAML_PATH).read_text())
         except FileNotFoundError:

--- a/python/cli/data_platform_workflows_cli/update_bundle.py
+++ b/python/cli/data_platform_workflows_cli/update_bundle.py
@@ -279,8 +279,10 @@ def main():
             old_snaps_data = {}
 
         if old_snaps_data != snaps_data:
+            print(old_snaps_data)
+            print(snaps_data)
             updates_available = True
             with open(SNAPS_YAML_PATH, "w") as file:
-                yaml.dump(snaps_data, file)
+                yaml.dump(snaps_data, file, sort_keys=True)
 
     github_actions.output["updates_available"] = json.dumps(updates_available)


### PR DESCRIPTION
## Issue

The workflow mistakenly created PRs for updating the snaps list because of ordering, even though the revisions itself didn't change. This is because, for python:

```
> {"packages": ["snap1", "snap2", "snap3"]} != {"packages": ["snap1", "snap3", "snap2"]}
True
```
then, `snaps != old_snaps` was being set to true every time, and the output of `updates_available` was mistakenly being set to `true`
## Solution

Sort the snaps list. See test runs: 

postgresql: https://github.com/canonical/postgresql-bundle/commit/d5056b5f706d554ad65c45e13be39200a0d82437
mysql: https://github.com/canonical/mysql-bundle/commit/4269833c7c0e9fcb01407d5c93e93671688de616