### PR TITLE
compatible(integration_test_charm): Add input that would enable metallb for integration tests

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -324,6 +324,7 @@ jobs:
         run: |
           # `--classic` applies to juju 2 snap; ignored for juju 3 snap
           sudo snap install juju --classic --channel='${{ steps.parse-versions.outputs.snap_channel }}'
+          sudo snap install jq
       - name: Set up lxd
         timeout-minutes: 5
         if: ${{ inputs.cloud == 'lxd' }}
@@ -369,10 +370,6 @@ jobs:
           sg '${{ steps.parse-cloud.outputs.group }}' -c "microk8s.kubectl rollout status --namespace kube-system --watch --timeout=5m deployments/hostpath-provisioner"
           if [[ '${{ inputs.metallb-addon }}' = 'true' ]]
           then
-            if [[ '${{ inputs.architecture }}' == 'arm64' ]]
-            then
-              sudo snap install jq
-            fi
             IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
             sg '${{ steps.parse-cloud.outputs.group }}' -c "retry --times 3 --delay 5 -- sudo microk8s enable metallb:$IPADDR-$IPADDR"
           fi

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -43,6 +43,7 @@ on:
           Whether to enable metallb
           required: false
         type: boolean
+        default: false
       lxd-snap-channel:
         description: LXD snap channel
         default: latest/stable

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -370,7 +370,7 @@ jobs:
           if [[ '${{ inputs.metallb-addon }}' = 'true' ]]
           then
             IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
-            sg '${{ steps.parse-cloud.outputs.group }}' -c "retry --times 3 --delay 5 -- sudo microks enable metallb:$IPADDR-$IPADDR"
+            sg '${{ steps.parse-cloud.outputs.group }}' -c "retry --times 3 --delay 5 -- sudo microk8s enable metallb:$IPADDR-$IPADDR"
           fi
           mkdir ~/.kube/
           # Used by lightkube and kubernetes (Python package)

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -38,6 +38,11 @@ on:
           Required if `cloud` input is "microk8s"
         required: false
         type: string
+      metallb-addon:
+        description: |
+          Whether to enable metallb
+          required: false
+          type: boolean
       lxd-snap-channel:
         description: LXD snap channel
         default: latest/stable
@@ -362,6 +367,11 @@ jobs:
           sg '${{ steps.parse-cloud.outputs.group }}' -c "microk8s.kubectl rollout status --namespace kube-system --watch --timeout=5m deployments/coredns"
           sg '${{ steps.parse-cloud.outputs.group }}' -c "retry --times 3 --delay 5 -- sudo microk8s enable hostpath-storage"
           sg '${{ steps.parse-cloud.outputs.group }}' -c "microk8s.kubectl rollout status --namespace kube-system --watch --timeout=5m deployments/hostpath-provisioner"
+          if [[ '${{ inputs.metallb-addon }}' = 'true' ]]
+          then
+            IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
+            sg '${{ steps.parse-cloud.outputs.group }}' -c "retry --times 3 --delay 5 -- sudo microks enable metallb:$IPADDR-$IPADDR"
+          fi
           mkdir ~/.kube/
           # Used by lightkube and kubernetes (Python package)
           sg '${{ steps.parse-cloud.outputs.group }}' -c "microk8s config > ~/.kube/config"

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -369,6 +369,10 @@ jobs:
           sg '${{ steps.parse-cloud.outputs.group }}' -c "microk8s.kubectl rollout status --namespace kube-system --watch --timeout=5m deployments/hostpath-provisioner"
           if [[ '${{ inputs.metallb-addon }}' = 'true' ]]
           then
+            if [[ '${{ inputs.architecture }}' == 'arm64' ]]
+            then
+              sudo snap install jq
+            fi
             IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
             sg '${{ steps.parse-cloud.outputs.group }}' -c "retry --times 3 --delay 5 -- sudo microk8s enable metallb:$IPADDR-$IPADDR"
           fi

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -324,7 +324,6 @@ jobs:
         run: |
           # `--classic` applies to juju 2 snap; ignored for juju 3 snap
           sudo snap install juju --classic --channel='${{ steps.parse-versions.outputs.snap_channel }}'
-          sudo snap install jq
       - name: Set up lxd
         timeout-minutes: 5
         if: ${{ inputs.cloud == 'lxd' }}
@@ -370,7 +369,7 @@ jobs:
           sg '${{ steps.parse-cloud.outputs.group }}' -c "microk8s.kubectl rollout status --namespace kube-system --watch --timeout=5m deployments/hostpath-provisioner"
           if [[ '${{ inputs.metallb-addon }}' = 'true' ]]
           then
-            IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
+            IPADDR=$(ip -4 -j route get 2.2.2.2 | sed -n -e 's/^.*prefsrc\":"\([^ "]*\).*/\1/p')
             sg '${{ steps.parse-cloud.outputs.group }}' -c "retry --times 3 --delay 5 -- sudo microk8s enable metallb:$IPADDR-$IPADDR"
           fi
           mkdir ~/.kube/

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -42,7 +42,7 @@ on:
         description: |
           Whether to enable metallb
           required: false
-          type: boolean
+        type: boolean
       lxd-snap-channel:
         description: LXD snap channel
         default: latest/stable


### PR DESCRIPTION
We need metallb enabled for integration tests where we are creating `loadbalancer` type service in https://github.com/canonical/mysql-router-k8s-operator/pull/328

Add ability to enable metallb