### PR TITLE
compatible: Adapt collect-bases step to parse `platforms` keyword

### DIFF
--- a/python/cli/data_platform_workflows_cli/craft_tools/collect_bases.py
+++ b/python/cli/data_platform_workflows_cli/craft_tools/collect_bases.py
@@ -28,7 +28,7 @@ RUNNERS = {
 }
 
 
-def get_bases(*, craft_: craft.Craft, yaml_data):
+def get_bases(*, craft_: craft.Craft, yaml_data: dict):
     """Get architecture for each base
 
     For charms, multiple bases can have the same architecture

--- a/python/cli/data_platform_workflows_cli/craft_tools/collect_bases.py
+++ b/python/cli/data_platform_workflows_cli/craft_tools/collect_bases.py
@@ -36,7 +36,7 @@ def get_bases(*, craft_: craft.Craft, yaml_data):
 
     For snaps & rocks, the Ubuntu version is the same for all architectures.
     """
-    if craft_ is craft.Craft.ROCK:
+    if craft_ is craft.Craft.ROCK or "platforms" in yaml_data:
         # https://canonical-rockcraft.readthedocs-hosted.com/en/latest/reference/rockcraft.yaml/#platforms
         return [craft.Architecture(arch) for arch in yaml_data["platforms"]]
     if craft_ is craft.Craft.SNAP:

--- a/python/pytest_plugins/pytest_operator_cache/pytest_operator_cache/_plugin.py
+++ b/python/pytest_plugins/pytest_operator_cache/pytest_operator_cache/_plugin.py
@@ -47,7 +47,7 @@ async def build_charm(
         ), f"Architecture for {bases_index=} ({architectures[0]}) does not match host architecture ({architecture})"
         packed_charms = list(charm_path.glob(f"*{version}-{architecture}.charm"))
     else:
-        packed_charms = list(charm_path.glob(f"*-{architecture}.charm"))
+        packed_charms = list(charm_path.glob(f"*{architecture}.charm"))
     if len(packed_charms) == 1:
         # python-libjuju's model.deploy(), juju deploy, and juju bundle files expect local charms
         # to begin with `./` or `/` to distinguish them from Charmhub charms.


### PR DESCRIPTION
- Small adaptations to make related workflows parse the new `platforms` keyword for snaps and charms (like what's already in place for rocks).
- Adapt the `build_charm` helper to the new charmcraft 3.x naming:  `<charm>_<arch>.charm`

Test workflows:

- For charm: https://github.com/canonical/postgresql-operator/pull/680
- For snap: https://github.com/canonical/charmed-postgresql-snap/pull/63