### PR TITLE
patch(build_charm.yaml): Update APT indexes before installing libpq-dev

### DIFF
--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -90,7 +90,9 @@ jobs:
       - name: (GitHub-hosted ARM runner) Install libpq-dev
         if: ${{ matrix.base.runner == 'Ubuntu_ARM64_4C_16G_02' }}
         # Needed for `charmcraftcache` to resolve dependencies (for postgresql charms with psycopg2)
-        run: sudo apt-get install libpq-dev -y
+        run: |
+          sudo apt-get update
+          sudo apt-get install libpq-dev -y
       - name: Get workflow version
         id: workflow-version
         uses: canonical/get-workflow-version-action@v1


### PR DESCRIPTION
This fixes an issue where it fails due to trying to install an older version which no longer exists.

See https://github.com/canonical/postgresql-operator/actions/runs/12155829148/job/33898208024 for https://github.com/canonical/postgresql-operator/pull/690

![OQQmarvpBu](https://github.com/user-attachments/assets/de1bd37b-db24-499d-a425-182cdfe4d460)

```
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  postgresql-doc-14
The following NEW packages will be installed:
  libpq-dev
0 upgraded, 1 newly installed, 0 to remove and 26 not upgraded.
Need to get 148 kB of archives.
After this operation, 589 kB of additional disk space will be used.
Ign:1 http://ports.ubuntu.com/ubuntu-ports jammy-updates/main arm64 libpq-dev arm64 14.13-0ubuntu0.22.04.1
Err:1 http://ports.ubuntu.com/ubuntu-ports jammy-updates/main arm64 libpq-dev arm64 14.13-0ubuntu0.22.04.1
  404  Not Found [IP: 185.125.190.39 80]
E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/p/postgresql-14/libpq-dev_14.13-0ubuntu0.22.04.1_arm64.deb  404  Not Found [IP: 185.125.190.39 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

Where it tries `14.13-0ubuntu0.22.04.1`, but per https://launchpad.net/ubuntu/+source/postgresql-14, it's at `14.15-0ubuntu0.22.04.1`.

One other solution is to ensure we always use the daily images.