### PR TITLE
breaking(build_charm.yaml): Enable cache by default

### DIFF
--- a/.github/workflows/build_charm.md
+++ b/.github/workflows/build_charm.md
@@ -10,12 +10,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v0.0.0
 ```
 
-If you use
-```yaml
-with:
-  cache: true
-```
-remember to add your charm's branch(es) to charmcraftcache by running `ccc add` or by [opening an issue](https://github.com/canonical/charmcraftcache-hub/issues/new?assignees=&labels=add-charm&projects=&template=add_charm_branch.yaml&title=Add+charm+branch).
+Unless you disable caching (with `cache: false`), remember to add your charm's branch(es) to charmcraftcache: https://github.com/canonical/charmcraftcache?tab=readme-ov-file#usage
 
 ### Required charmcraft.yaml syntax
 Only [ST124 - Multi-base platforms in craft tools](https://docs.google.com/document/d/1QVHxZumruKVZ3yJ2C74qWhvs-ye5I9S6avMBDHs2YcQ/edit) "shorthand notation" syntax is supported

--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -7,11 +7,8 @@ on:
   workflow_call:
     inputs:
       cache:
-        description: |
-          Whether to use cache for faster builds
-          
-          Should be `false` for production builds
-        default: false
+        description: Whether to use cache for faster builds
+        default: true
         type: boolean
       artifact-prefix:
         description: Charm packages are uploaded to GitHub artifacts beginning with this prefix


### PR DESCRIPTION
Cached builds will be used for release & integration tests, so that we release the same *.charm file that is tested

Signed by Mykola & Jon in https://docs.google.com/document/d/1Wt0ds4dEcih4cvHWkbvvALtqonC_D9crcNQteX34SUg/edit?pli=1&tab=t.0