### PR TITLE
patch(build_charm.yaml): Remove libpq-dev install

### DIFF
--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -87,12 +87,6 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 120
     steps:
-      - name: (GitHub-hosted ARM runner) Install libpq-dev
-        if: ${{ matrix.platform.runner == 'Ubuntu_ARM64_4C_16G_02' }}
-        # Needed for `charmcraftcache` to resolve dependencies (for postgresql charms with psycopg2)
-        run: |
-          sudo apt-get update
-          sudo apt-get install libpq-dev -y
       - name: Get workflow version
         id: workflow-version
         uses: canonical/get-workflow-version-action@v1


### PR DESCRIPTION
After charmcraftcache refactor to per-repository caches instead of global cache (charmcraftcache v0.5.0), this is no longer needed