### PR TITLE
breaking: Show craft logs instead of uploading to artifact

### DIFF
--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -137,13 +137,9 @@ jobs:
         env:
           # Used by charmcraftcache (to avoid GitHub API rate limit)
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload charmcraft logs
-        if: ${{ failure() && steps.pack.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: logs-charmcraft-build-${{ needs.collect-platforms.outputs.artifact-prefix-with-inputs }}-platform-${{ matrix.platform.name_in_artifact }}
-          path: ~/.local/state/charmcraft/log/
-          if-no-files-found: error
+      - name: Charmcraft logs
+        if: ${{ success() || (failure() && steps.pack.outcome == 'failure') }}
+        run: cat ~/.local/state/charmcraft/log/*
       - run: touch .empty
       - name: Upload charm package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_rock.yaml
+++ b/.github/workflows/build_rock.yaml
@@ -94,13 +94,9 @@ jobs:
         id: pack
         working-directory: ${{ inputs.path-to-rock-directory }}
         run: sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- rockcraft pack -v --platform='${{ matrix.platform.name }}'
-      - name: Upload rockcraft logs
-        if: ${{ failure() && steps.pack.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: logs-rockcraft-build-${{ inputs.artifact-prefix }}-platform-${{ matrix.platform.name }}
-          path: ~/.local/state/rockcraft/log/
-          if-no-files-found: error
+      - name: Rockcraft logs
+        if: ${{ success() || (failure() && steps.pack.outcome == 'failure') }}
+        run: cat ~/.local/state/rockcraft/log/*
       - run: touch .empty
       - name: Upload rock package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -97,13 +97,9 @@ jobs:
         id: pack
         working-directory: ${{ inputs.path-to-snap-project-directory }}
         run: sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- snapcraft pack -v --build-for='${{ matrix.platform.name }}'
-      - name: Upload snapcraft logs
-        if: ${{ failure() && steps.pack.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: logs-snapcraft-build-${{ inputs.artifact-prefix }}-platform-${{ matrix.platform.name }}
-          path: ~/.local/state/snapcraft/log/
-          if-no-files-found: error
+      - name: Snapcraft logs
+        if: ${{ success() || (failure() && steps.pack.outcome == 'failure') }}
+        run: cat ~/.local/state/snapcraft/log/*
       - run: touch .empty
       - name: Upload snap package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release_charm.yaml
+++ b/.github/workflows/release_charm.yaml
@@ -75,10 +75,6 @@ jobs:
         env:
           CHARMCRAFT_AUTH: ${{ secrets.charmhub-token }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload charmcraft logs
-        if: ${{ failure() && steps.release.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: logs-charmcraft-release-${{ inputs.artifact-prefix }}
-          path: ~/.local/state/charmcraft/log/
-          if-no-files-found: ignore
+      - name: Charmcraft logs
+        if: ${{ success() || (failure() && steps.release.outcome == 'failure') }}
+        run: cat ~/.local/state/charmcraft/log/*

--- a/.github/workflows/release_snap.yaml
+++ b/.github/workflows/release_snap.yaml
@@ -79,10 +79,6 @@ jobs:
           SNAPCRAFT_STORE_AUTH: candid
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snap-store-token }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload snapcraft logs
-        if: ${{ failure() && steps.release.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: logs-snapcraft-release-${{ inputs.artifact-prefix }}
-          path: ~/.local/state/snapcraft/log/
-          if-no-files-found: ignore
+      - name: Snapcraft logs
+        if: ${{ success() || (failure() && steps.release.outcome == 'failure') }}
+        run: cat ~/.local/state/snapcraft/log/*


### PR DESCRIPTION
Print snapcraft/rockcraft/charmcraft logs to GitHub Actions log instead of uploading log file to artifact

Also show logs on success & failure instead of just on failure