### PR TITLE
patch(build_*.yaml): Use GitHub-hosted free ARM runners

### DIFF
--- a/python/cli/data_platform_workflows_cli/craft_tools/collect_platforms.py
+++ b/python/cli/data_platform_workflows_cli/craft_tools/collect_platforms.py
@@ -25,7 +25,7 @@ from . import charmcraft_platforms
 logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 RUNNERS = {
     craft.Architecture.X64: "ubuntu-latest",
-    craft.Architecture.ARM64: "Ubuntu_ARM64_4C_16G_02",
+    craft.Architecture.ARM64: "ubuntu-24.04-arm",
 }
 
 


### PR DESCRIPTION
Switch from paid GitHub-hosted ARM runners to public preview free runners (https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)

Will switch integration_test_charm.yaml from Azure ARM runners to GitHub ARM runners once the GitHub ARM runners are Generally Available