### PR TITLE
compatible: Add check_charm_pr.yaml

### DIFF
--- a/.github/workflows/_promote_charm.md
+++ b/.github/workflows/_promote_charm.md
@@ -1,0 +1,89 @@
+Workflow file: [_promote_charm.yaml](_promote_charm.yaml)
+
+> [!WARNING]
+> Subject to **breaking changes on patch release**. `_promote_charm.yaml` is experimental & not part of the public interface.
+
+## Limitations
+Currently, this workflow can only be used on repositories that contain a single charm (that needs to be promoted; additional unreleased test charms are okay). That charm must be located at the root of the repository directory (i.e. `charmcraft.yaml` is present in the root of the repository)
+
+## Usage
+### Step 1: Add `promote.yaml` file to `.github/workflows/`
+```yaml
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Promote charm
+
+on:
+  workflow_dispatch:
+    inputs:
+      from-risk:
+        description: Promote from this Charmhub risk
+        required: true
+        type: choice
+        options:
+          - edge
+          - beta
+          - candidate
+      to-risk:
+        description: Promote to this Charmhub risk
+        required: true
+        type: choice
+        options:
+          - beta
+          - candidate
+          - stable
+
+jobs:
+  promote:
+    name: Promote charm
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_charm.yaml@v0.0.0
+    with:
+      track: latest
+      from-risk: ${{ inputs.from-risk }}
+      to-risk: ${{ inputs.to-risk }}
+    secrets:
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+    permissions:
+      contents: write  # Needed to update git tags
+```
+### Step 2: Add `check_pr.yaml` file to `.github/workflows/`
+```yaml
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Check pull request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - edited
+    branches:
+      - main
+
+jobs:
+  check-pr:
+    name: Check pull request
+    uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@v0.0.0
+```
+Update `branches` to include all branches that [`release_charm.yaml`](release_charm.md) runs on
+
+### Step 3: Add `.github/release.yaml` file
+```yaml
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+```
+
+### Step 4: Ensure metadata.yaml file is present
+This workflow requires the charm directory (directory with charmcraft.yaml) to contain a metadata.yaml file with the `name` and `display-name` keys. Syntax: https://juju.is/docs/sdk/metadata-yaml
+
+"Unified charmcraft.yaml syntax" (where actions.yaml, charmcraft.yaml, config.yaml, and metadata.yaml are combined into a single charmcraft.yaml file) is not supported.
+
+Rationale in [release_charm.md](release_charm.md#rationale)

--- a/.github/workflows/_promote_charm.yaml
+++ b/.github/workflows/_promote_charm.yaml
@@ -1,0 +1,78 @@
+on:
+  workflow_call:
+    inputs:
+      track:
+        description: |
+          Charmhub track
+
+          https://juju.is/docs/juju/channel#heading--track
+        required: true
+        type: string
+      from-risk:
+        description:
+          Promote from `track` input and this Charmhub risk
+
+          https://juju.is/docs/juju/channel#heading--risk
+
+          Must be one of "edge", "beta", "candidate"
+        required: true
+        type: string
+      to-risk:
+        description:
+          Promote to `track` input and this Charmhub risk
+
+          https://juju.is/docs/juju/channel#heading--risk
+
+          Must be one of "beta", "candidate", "stable"
+        required: true
+        type: string
+      charmcraft-snap-revision:
+        description: charmcraft snap revision
+        required: false
+        type: string
+      charmcraft-snap-channel:
+        description: |
+          charmcraft snap channel
+
+          Cannot be used if `charmcraft-snap-revision` input is passed
+        required: false
+        type: string
+    secrets:
+      charmhub-token:
+        description: Charmhub login token
+        required: true
+
+jobs:
+  promote-charm:
+    name: Promote charm from ${{ inputs.track }}/${{ inputs.from-risk }} to ${{ inputs.track }}/${{ inputs.to-risk }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Get workflow version
+        id: workflow-version
+        uses: canonical/get-workflow-version-action@v1
+        with:
+          repository-name: canonical/data-platform-workflows
+          file-name: _promote_charm.yaml
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install CLI
+        run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=python/cli
+      - name: Parse charmcraft version inputs
+        id: charmcraft-snap-version
+        run: parse-snap-version --revision='${{ inputs.charmcraft-snap-revision }}' --channel='${{ inputs.charmcraft-snap-channel }}' --revision-input-name=charmcraft-snap-revision --channel-input-name=charmcraft-snap-channel
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic ${{ steps.charmcraft-snap-version.outputs.install_flag }}
+      - run: snap list
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Checkout history with git tags
+      - name: Promote charm
+        id: promote
+        run: promote-charm --track='${{ inputs.track }}' --from-risk='${{ inputs.from-risk }}' --to-risk='${{ inputs.to-risk }}' --ref='${{ github.ref }}'
+        env:
+          CHARMCRAFT_AUTH: ${{ secrets.charmhub-token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Charmcraft logs
+        if: ${{ success() || (failure() && steps.promote.outcome == 'failure') }}
+        run: cat ~/.local/state/charmcraft/log/*

--- a/.github/workflows/check_charm_pr.md
+++ b/.github/workflows/check_charm_pr.md
@@ -1,0 +1,4 @@
+Workflow file: [check_charm_pr.yaml](check_charm_pr.yaml)
+
+## Usage
+See [_promote_charm.md](_promote_charm.md)

--- a/.github/workflows/check_charm_pr.yaml
+++ b/.github/workflows/check_charm_pr.yaml
@@ -1,0 +1,34 @@
+on:
+  workflow_call:
+
+jobs:
+  check-pr:
+    name: Check pull request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check pull request
+        shell: python
+        run: |
+          import json
+          import os
+
+          RELEASE_NOTES_LABELS = ["bug", "enhancement", "not bug or enhancement"]
+
+          LABELS_MESSAGE = f"{', '.join(repr(label) for label in RELEASE_NOTES_LABELS[:-1])}, or {repr(RELEASE_NOTES_LABELS[-1])}"
+
+          pr_labels = json.loads(os.environ["LABELS"])
+          pr_release_notes_labels = set(pr_labels).intersection(RELEASE_NOTES_LABELS)
+          if len(pr_release_notes_labels) == 0:
+              raise ValueError(
+                  f"Pull request must have {LABELS_MESSAGE} label in order to generate release notes"
+              )
+          if len(pr_release_notes_labels) > 1:
+              raise ValueError(
+                  f"Pull request can only have 1 of the {LABELS_MESSAGE} labels in order to generate "
+                  f"release notes. Got {len(pr_release_notes_labels)} labels: "
+                  f"{repr(pr_release_notes_labels)}"
+              )
+        # Use env variable to avoid script injection & accept multi-line strings
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}

--- a/.github/workflows/release_charm.md
+++ b/.github/workflows/release_charm.md
@@ -1,7 +1,7 @@
 Workflow file: [release_charm.yaml](release_charm.yaml)
 
 ## Usage
-Add `.yaml` file to `.github/workflows/`
+Add `release.yaml` file to `.github/workflows/`
 ```yaml
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/.github/workflows/release_rock.md
+++ b/.github/workflows/release_rock.md
@@ -1,7 +1,7 @@
 Workflow file: [release_rock.yaml](release_rock.yaml)
 
 ## Usage
-Add `.yaml` file to `.github/workflows/`
+Add `release.yaml` file to `.github/workflows/`
 ```yaml
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/.github/workflows/release_snap.md
+++ b/.github/workflows/release_snap.md
@@ -1,7 +1,7 @@
 Workflow file: [release_snap.yaml](release_snap.yaml)
 
 ## Usage
-Add `.yaml` file to `.github/workflows/`
+Add `release.yaml` file to `.github/workflows/`
 ```yaml
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/.github/workflows/sync_docs.md
+++ b/.github/workflows/sync_docs.md
@@ -1,7 +1,7 @@
 Workflow file: [sync_docs.yaml](sync_docs.yaml)
 
 ## Usage
-Add `.yaml` file to `.github/workflows/`
+Add `sync_docs.yaml` file to `.github/workflows/`
 
 ```yaml
 # Copyright 2024 Canonical Ltd.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 ## Usage
 ### Workflows
-| Name                                                                       | Description                                                                |
-|----------------------------------------------------------------------------|----------------------------------------------------------------------------|
-| [lint.yaml](.github/workflows/lint.md)                                     | Lint GitHub Actions workflows (`.github/workflows/`) and `tox run -e lint` |
-| [build_snap.yaml](.github/workflows/build_snap.md)                         | Build snap                                                                 |
-| [build_rock.yaml](.github/workflows/build_rock.md)                         | Build rock                                                                 |
-| [build_charm.yaml](.github/workflows/build_charm.md)                       | Build charm                                                                |
-| [release_snap.yaml](.github/workflows/release_snap.md)                     | Release snap to Snap Store                                                 |
-| [release_rock.yaml](.github/workflows/release_rock.md)                     | Release rock to GitHub Container Registry                                  |
-| [release_charm.yaml](.github/workflows/release_charm.md)                   | Release charm to Charmhub                                                  |
-| [sync_docs.yaml](.github/workflows/sync_docs.md)                           | Sync Discourse documentation to GitHub                                     |
-| [_update_bundle.yaml](.github/workflows/_update_bundle.md)                 | **Experimental** Update charm revisions in bundle                          |
-| [integration_test_charm.yaml](.github/workflows/integration_test_charm.md) | **Deprecated** Integration test charm                                      |
+| Name                                                                       | Description                                                                      |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| [lint.yaml](.github/workflows/lint.md)                                     | Lint GitHub Actions workflows (`.github/workflows/`) and `tox run -e lint`       |
+| [build_snap.yaml](.github/workflows/build_snap.md)                         | Build snap                                                                       |
+| [build_rock.yaml](.github/workflows/build_rock.md)                         | Build rock                                                                       |
+| [build_charm.yaml](.github/workflows/build_charm.md)                       | Build charm                                                                      |
+| [release_snap.yaml](.github/workflows/release_snap.md)                     | Release snap to Snap Store                                                       |
+| [release_rock.yaml](.github/workflows/release_rock.md)                     | Release rock to GitHub Container Registry                                        |
+| [release_charm.yaml](.github/workflows/release_charm.md)                   | Release charm to Charmhub                                                        |
+| [_promote_charm.yaml](.github/workflows/_promote_charm.md)                 | **Experimental** `charmcraft promote`, update git tags, & generate release notes |
+| [check_charm_pr.yaml](.github/workflows/check_charm_pr.md)                 | Check charm pull request has required labels for release notes                   |
+| [sync_docs.yaml](.github/workflows/sync_docs.md)                           | Sync Discourse documentation to GitHub                                           |
+| [_update_bundle.yaml](.github/workflows/_update_bundle.md)                 | **Experimental** Update charm revisions in bundle                                |
+| [integration_test_charm.yaml](.github/workflows/integration_test_charm.md) | **Deprecated** Integration test charm                                            |
 
 ### Version
 Recommendation: pin the latest version (e.g. `v1.0.0`) and use [Renovate](https://docs.renovatebot.com/) to stay up-to-date.

--- a/python/cli/data_platform_workflows_cli/craft_tools/promote.py
+++ b/python/cli/data_platform_workflows_cli/craft_tools/promote.py
@@ -1,0 +1,260 @@
+import argparse
+import enum
+import logging
+import pathlib
+import subprocess
+import sys
+
+import requests
+import yaml
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+
+
+class Direction(enum.StrEnum):
+    FROM = "from"
+    TO = "to"
+
+
+class Risk(enum.StrEnum):
+    """Charmhub risk"""
+
+    # In order from lowest to highest risk
+    STABLE = "stable"
+    CANDIDATE = "candidate"
+    BETA = "beta"
+    EDGE = "edge"
+
+    @classmethod
+    def get(cls, value, *, direction: Direction):  # Cannot override __call__ or __new__
+        valid_risks = [risk.value for risk in cls]
+        if direction is Direction.FROM:
+            valid_risks.remove(Risk.STABLE.value)
+        elif direction is Direction.TO:
+            valid_risks.remove(Risk.EDGE.value)
+        else:
+            raise TypeError
+        if value not in valid_risks:
+            raise ValueError(
+                f"`{direction.value}-risk` input must be one of {repr(valid_risks)}, got: "
+                f"{repr(value)}"
+            )
+        return cls(value)
+
+    def __lt__(self, other):
+        if not isinstance(other, Risk):
+            # Raise instead of `return NotImplemented` since this class inherits from `str`
+            raise TypeError
+        order = list(Risk)
+        return order.index(self) < order.index(other)
+
+
+def get_commit_sha_and_revisions(
+    *, channel: str, charm_name: str, tag_prefix: str, channel_missing_ok=False
+):
+    """Get (& verify) commit sha that all charm revisions on a Charmhub channel were built from
+
+    Returns (commit sha, charm revisions)
+    """
+    logging.info(f"Getting revisions on {repr(channel)}")
+    response = requests.get(
+        f"https://api.snapcraft.io/v2/charms/info/{charm_name}?fields=channel-map&channel={channel}"
+    )
+    response.raise_for_status()
+    channel_map = response.json()["channel-map"]
+    revisions: list[int] = [item["revision"]["revision"] for item in channel_map]
+    if not revisions:
+        if channel_missing_ok:
+            logging.info(f"No revisions exist on {repr(channel)}")
+            return
+        raise ValueError(f"No revisions exist on {repr(channel)}")
+    logging.info(f"Revisions on {repr(channel)}: {repr(revisions)}")
+
+    logging.info("Checking that revisions were built from the same git commit")
+    commit_shas = set()
+    for revision in revisions:
+        tag = f"{tag_prefix}{revision}"
+        try:
+            commit_shas.add(
+                subprocess.run(
+                    ["git", "rev-parse", tag], capture_output=True, check=True, text=True
+                ).stdout.strip()
+            )
+        except subprocess.CalledProcessError:
+            logging.error(
+                f"Unable to find git tag {repr(tag)}. Was revision {revision} released with "
+                "data-platform-workflows release_charm.yaml?"
+            )
+            raise
+    if len(commit_shas) != 1:
+        raise ValueError(
+            f"Revisions {repr(revisions)} were built from different git commits: "
+            f"{repr(commit_shas)}. Revisions must be built from the same git commit to correctly "
+            "apply git tags for risk (e.g. '14/beta')"
+        )
+    commit_sha = commit_shas.pop()
+    logging.info(f"All revisions on {repr(channel)} were built from git commit {repr(commit_sha)}")
+    return commit_sha, revisions
+
+
+def charm():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--track", required=True)
+    parser.add_argument("--from-risk", required=True)
+    parser.add_argument("--to-risk", required=True)
+    parser.add_argument("--ref", required=True)
+    args = parser.parse_args()
+    directory = pathlib.Path(".")
+
+    metadata_file = yaml.safe_load((directory / "metadata.yaml").read_text())
+    charm_name = metadata_file["name"]
+    charm_display_name = metadata_file["display-name"]
+
+    track = args.track
+    if "/" in track:
+        raise ValueError(f"`track` input cannot contain '/' character: {repr(track)}")
+    from_risk = Risk.get(args.from_risk, direction=Direction.FROM)
+    to_risk = Risk.get(args.to_risk, direction=Direction.TO)
+    if not to_risk < from_risk:
+        raise ValueError(
+            f"`to-risk` input ({repr(to_risk.value)}) must be lower risk than `from-risk` input "
+            f"({repr(from_risk.value)})"
+        )
+    if to_risk is Risk.STABLE and from_risk is not Risk.CANDIDATE:
+        raise ValueError(
+            "Only the 'candidate' risk can be promoted to 'stable'. Promote "
+            f"{repr(from_risk.value)} to 'candidate' first"
+        )
+
+    if not args.ref.startswith("refs/heads/"):
+        raise ValueError(
+            f"This workflow must be run on `workflow_dispatch` from the branch that contains track {repr(track)}"
+        )
+    target_branch = args.ref.removeprefix("refs/heads/")
+
+    if not pathlib.Path(".github/release.yaml").exists():
+        raise FileNotFoundError(
+            "Repository must contain `.github/release.yaml` to automatically generate release "
+            "notes in the correct format. See "
+            "https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/promote_charm.md#step-3-add-githubreleaseyaml-file"
+        )
+
+    from_channel = f"{track}/{from_risk}"
+    to_channel = f"{track}/{to_risk}"
+
+    # `tag_prefix` format from release_charm.yaml
+    if directory == pathlib.Path("."):
+        tag_prefix = "rev"
+    else:
+        tag_prefix = f"{charm_name}/rev"
+
+    logging.info("Checking that revisions that will be promoted are from the same git commit")
+    # Check before promoting so that we fail early if `from_channel` revisions were built from
+    # different git commits.
+    # But don't store return value to avoid race condition if `from_channel` changes before
+    # `charmcraft promote` is run. Instead, get commit sha again from `to_channel` after promoting
+    get_commit_sha_and_revisions(channel=from_channel, charm_name=charm_name, tag_prefix=tag_prefix)
+    if to_risk is Risk.CANDIDATE:
+        # We will need to get commit for most recent stable release
+        stable_channel = f"{track}/{Risk.STABLE.value}"
+        logging.info(f"Checking that {repr(stable_channel)} revisions are from the same git commit")
+        get_commit_sha_and_revisions(
+            channel=stable_channel,
+            charm_name=charm_name,
+            tag_prefix=tag_prefix,
+            channel_missing_ok=True,  # In case no previous stable release
+        )
+
+    logging.info(
+        f"Promoting {repr(charm_name)} charm from {repr(from_channel)} to {repr(to_channel)}"
+    )
+    subprocess.run(
+        [
+            "charmcraft",
+            "promote",
+            "--name",
+            charm_name,
+            "--from-channel",
+            from_channel,
+            "--to-channel",
+            to_channel,
+            "--yes",
+        ],
+        check=True,
+    )
+
+    logging.info("Getting git commit of revisions that were promoted")
+    promoted_commit_sha, charm_revisions = get_commit_sha_and_revisions(
+        channel=to_channel, charm_name=charm_name, tag_prefix=tag_prefix
+    )
+
+    logging.info(f"Updating git tag {repr(to_channel)}")
+    subprocess.run(["git", "tag", to_channel, promoted_commit_sha, "--force"], check=True)
+    subprocess.run(["git", "push", "origin", to_channel, "--force"], check=True)
+
+    possible_release_tags = [f"{tag_prefix}{revision}" for revision in charm_revisions]
+    # Pick alphabetically first tag because of
+    # https://github.com/orgs/community/discussions/149281#discussioncomment-12071170
+    github_release_tag = sorted(possible_release_tags)[0]
+
+    if to_risk is Risk.CANDIDATE:
+        # Get tag for most recent stable release
+        stable_channel = f"{track}/{Risk.STABLE.value}"
+        logging.info(f"Getting git tag for most recent {repr(stable_channel)} release")
+        output = get_commit_sha_and_revisions(
+            channel=stable_channel,
+            charm_name=charm_name,
+            tag_prefix=tag_prefix,
+            channel_missing_ok=True,  # In case no previous stable release
+        )
+        if output is None:
+            logging.warning(f"No existing release found on {repr(stable_channel)}")
+            previous_github_release_tag = None
+        else:
+            _, stable_revisions = output
+            possible_stable_release_tags = [
+                f"{tag_prefix}{revision}" for revision in stable_revisions
+            ]
+            # Pick alphabetically first tag because of
+            # https://github.com/orgs/community/discussions/149281#discussioncomment-12071170
+            previous_github_release_tag = sorted(possible_stable_release_tags)[0]
+            logging.info(
+                f"Found git tag for most recent {repr(stable_channel)} release: "
+                f"{repr(previous_github_release_tag)}"
+            )
+
+        if len(charm_revisions) > 1:
+            title = f"Revisions {', '.join(str(revision) for revision in sorted(charm_revisions))}"
+        else:
+            title = f"Revision {charm_revisions[0]}"
+        command = [
+            "gh",
+            "release",
+            "create",
+            github_release_tag,
+            "--verify-tag",
+            "--draft",
+            "--generate-notes",
+            # TODO: remove when charm refresh versioning implemented?
+            # If `--draft` is passed, `--latest` appears to have no affect on release editing
+            # in GitHub's UI (the UI will set latest by default regardless)
+            "--latest=false",
+            "--target",
+            target_branch,
+            "--title",
+            title,
+            "--notes",
+            # Say "/stable" in release notes so that it's correct when the release is published
+            f"""A new revision of {charm_display_name} has been published in the {track}/{Risk.STABLE.value} channel on [Charmhub](https://charmhub.io/{charm_name}).""",
+        ]
+        if previous_github_release_tag is not None:
+            command.extend(("--notes-start-tag", previous_github_release_tag))
+        logging.info("Creating GitHub draft release")
+        subprocess.run(command, check=True)
+    elif to_risk is Risk.STABLE:
+        # Publish GitHub release draft created during promotion to candidate risk
+        logging.info("Publishing GitHub release")
+        subprocess.run(
+            ["gh", "release", "edit", github_release_tag, "--verify-tag", "--draft=false"],
+            check=True,
+        )

--- a/python/cli/data_platform_workflows_cli/craft_tools/release.py
+++ b/python/cli/data_platform_workflows_cli/craft_tools/release.py
@@ -21,18 +21,17 @@ class OCIResource:
     revision: int
 
 
-def run(command_: list, *, log=True):
+def run(command_: list):
     """Run subprocess command & log stderr
 
     Returns:
         stdout
     """
-    process = subprocess.run(command_, capture_output=True, encoding="utf-8")
+    process = subprocess.run(command_, capture_output=True, text=True)
     try:
         process.check_returncode()
     except subprocess.CalledProcessError as e:
-        if log:
-            logging.error(e.stderr)
+        logging.error(e.stderr)
         raise
     return process.stdout.strip()
 

--- a/python/cli/pyproject.toml
+++ b/python/cli/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     {name = "Carl Csaposs", email = "carl.csaposs@canonical.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10"  # TODO: bump to >=3.12 when arm runners move to 24.04. enum.StrEnum requires >=3.11
 dependencies = [
     "pyyaml>=6.0.2",
     "requests>=2.32.3",
@@ -28,7 +28,14 @@ add-ssh-keys = "data_platform_workflows_cli.add_ssh_keys:main"
 tee-log-for-all-models = "data_platform_workflows_cli.tee_log_for_all_models:main"
 sync-docs = "data_platform_workflows_cli.sync_docs:main"
 compute-path-in-artifact = "data_platform_workflows_cli.compute_path_in_artifact:main"
+promote-charm = "data_platform_workflows_cli.craft_tools.promote:charm"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+extend-select = ["I", "UP"]


### PR DESCRIPTION
Add check_charm_pr.yaml and experimental _promote_charm.yaml

_promote_charm.yaml:
- runs `charmcraft promote`
- auto-generates charm release notes in a draft GitHub release when promoting to candidate
- publishes the draft GitHub release from candidate when promoting to stable
- updates git tags for track/beta, track/candidate, and track/stable (e.g. `14/beta`, `14/candidate`, `14/stable`)