### PR TITLE
breaking(release_charm.yaml): Use `noctua charm release` instead of calling charmcraft

### DIFF
--- a/.github/workflows/release_charm.yaml
+++ b/.github/workflows/release_charm.yaml
@@ -61,6 +61,8 @@ jobs:
         run: parse-snap-version --revision='${{ inputs.charmcraft-snap-revision }}' --channel='${{ inputs.charmcraft-snap-channel }}' --revision-input-name=charmcraft-snap-revision --channel-input-name=charmcraft-snap-channel
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic ${{ steps.charmcraft-snap-version.outputs.install_flag }}
+      - name: Install noctua
+        run: pipx install git+https://github.com/lucabello/noctua
       - run: snap list
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Context: https://docs.google.com/document/d/1Wt0ds4dEcih4cvHWkbvvALtqonC_D9crcNQteX34SUg/edit

Breaking change since behavior is different (charms are released one by one instead of uploading all charms, uploading all resources, and then releasing charms—so if upload-resource fails (happens somewhat regularly), some but not all charms might get released)

Also logging reduced (noctua does not support verbose output & JSON-parsable output simultaneously)