### PR TITLE
compatible: Deprecate sync_docs.yaml

### DIFF
--- a/.github/workflows/sync_docs.md
+++ b/.github/workflows/sync_docs.md
@@ -1,5 +1,8 @@
 Workflow file: [sync_docs.yaml](sync_docs.yaml)
 
+> [!WARNING]
+> This workflow is **deprecated** & will be removed in a future release.
+
 ## Usage
 Add `sync_docs.yaml` file to `.github/workflows/`
 

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -8,10 +8,14 @@ on:
 
 jobs:
   sync-docs:
-    name: Sync docs from Discourse
+    name: (deprecated) Sync docs from Discourse
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+    - name: Deprecation notice
+      run: |
+        # shellcheck disable=SC2016
+        echo '::warning::The `sync_docs.yaml` workflow is deprecated & will be removed in a future release.'
     - name: Get workflow version
       id: workflow-version
       uses: canonical/get-workflow-version-action@v1

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
 | [release_charm_pr.yaml](.github/workflows/release_charm_pr.md)               | Release pull request charm to Charmhub branch                                             |
 | [_promote_charm.yaml](.github/workflows/_promote_charm.md)                   | **Experimental** `charmcraft promote`, update git tags, & generate release notes          |
 | [check_charm_pr.yaml](.github/workflows/check_charm_pr.md)                   | Check charm pull request has required labels for release notes                            |
-| [sync_docs.yaml](.github/workflows/sync_docs.md)                             | Sync Discourse documentation to GitHub                                                    |
 | [approve_renovate_pr.yaml](.github/workflows/approve_renovate_pr.md)         | Reduce required approvals on [Renovate](https://docs.renovatebot.com/) pull requests by 1 |
 | [_update_bundle.yaml](.github/workflows/_update_bundle.md)                   | **Experimental** Update charm revisions in bundle                                         |
 | [integration_test_charm.yaml](.github/workflows/integration_test_charm.md)   | **Deprecated** Integration test charm                                                     |
+| [sync_docs.yaml](.github/workflows/sync_docs.md)                             | **Deprecated** Sync Discourse documentation to GitHub                                     |
 
 ### Version
 Recommendation: pin the latest version (e.g. `v1.0.0`) and use [Renovate](https://docs.renovatebot.com/) to stay up-to-date.


### PR DESCRIPTION
With the move to Sphinx + RTD (https://github.com/canonical/postgresql-operator/pull/919), the sync_docs.yaml workflow should not be added to charm repositories that are not already using it