### PR TITLE
patch(build_*.yaml): Only use PS6 runners for s390x

### DIFF
--- a/python/cli/data_platform_workflows_cli/craft_tools/collect_platforms.py
+++ b/python/cli/data_platform_workflows_cli/craft_tools/collect_platforms.py
@@ -26,8 +26,8 @@ logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 RUNNERS = {
     craft.Architecture.X64: "ubuntu-latest",
     craft.Architecture.ARM64: "ubuntu-24.04-arm",
-    # No sizes (e.g. "large") currently available for s390x IS-hosted runners
-    craft.Architecture.S390X: ["self-hosted", "s390x", "noble"],
+    # Use PS6 runners while PS7 runners unstable: https://chat.canonical.com/canonical/pl/3wcxtsrzo3ykdxe6rzp5uuus8h
+    craft.Architecture.S390X: "self-hosted-linux-s390x-noble-edge",
 }
 
 


### PR DESCRIPTION
PS7 runners are currently broken: https://chat.canonical.com/canonical/pl/3wcxtsrzo3ykdxe6rzp5uuus8h

Use PS6 runners instead of allowing PS6 & PS7 runners