### PR TITLE
patch: Update actions/download-artifact to v5

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -432,7 +432,7 @@ jobs:
         run: poetry add --lock --group integration juju@'${{ inputs.libjuju-version-constraint }}'
       - name: Download packed charm(s)
         timeout-minutes: 5
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
@@ -550,12 +550,12 @@ jobs:
       - name: Download default test collection results
         # Default test results in case the integration tests time out or runner set up fails
         # (So that Allure report will show "unknown"/"failed" test result, instead of omitting the test)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: allure-collection-default-results/
           name: allure-collection-default-results-integration-test-charm
       - name: Download test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: allure-results/
           pattern: allure-results-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || needs.integration-test.outputs.juju-snap-channel-for-artifact }}-${{ inputs.architecture }}-*

--- a/.github/workflows/release_charm_edge.yaml
+++ b/.github/workflows/release_charm_edge.yaml
@@ -69,7 +69,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-charm-directory }}'
       - name: Download charm package(s)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true

--- a/.github/workflows/release_charm_pr.yaml
+++ b/.github/workflows/release_charm_pr.yaml
@@ -66,7 +66,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-charm-directory }}'
       - name: Download charm package(s)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true

--- a/.github/workflows/release_python_package.md
+++ b/.github/workflows/release_python_package.md
@@ -56,7 +56,7 @@ jobs:
     environment: production
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ needs.release-part1.outputs.artifact-name }}
           path: dist/

--- a/.github/workflows/release_rock.yaml
+++ b/.github/workflows/release_rock.yaml
@@ -53,7 +53,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-rock-directory }}'
       - name: Download rock package(s)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true

--- a/.github/workflows/release_snap.yaml
+++ b/.github/workflows/release_snap.yaml
@@ -71,7 +71,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-snap-project-directory }}'
       - name: Download snap package(s)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true


### PR DESCRIPTION
Breaking change does not affect our usage; non-breaking: https://github.com/actions/download-artifact/releases/tag/v5.0.0