### PR TITLE
breaking: Update actions/checkout to v5

### DIFF
--- a/.github/workflows/__lint.yaml
+++ b/.github/workflows/__lint.yaml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install actionlint
         id: install
         run: |

--- a/.github/workflows/__release.yaml
+++ b/.github/workflows/__release.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Checkout history with git tags
       - name: Install CLI

--- a/.github/workflows/_promote_charm.yaml
+++ b/.github/workflows/_promote_charm.yaml
@@ -70,7 +70,7 @@ jobs:
         run: sudo snap install charmcraft --classic ${{ steps.charmcraft-snap-version.outputs.install_flag }}
       - run: snap list
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Checkout history with git tags
       - name: Promote charm

--- a/.github/workflows/_update_bundle.yaml
+++ b/.github/workflows/_update_bundle.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=python/cli
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.token }}
       - name: Update bundle file

--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=python/cli
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Collect charm platforms to build from charmcraft.yaml
         id: collect
         run: collect-charm-platforms --directory='${{ inputs.path-to-charm-directory }}'
@@ -105,7 +105,7 @@ jobs:
         id: lxd-snap-version
         run: parse-snap-version --revision='${{ inputs.lxd-snap-revision }}' --channel='${{ inputs.lxd-snap-channel }}' --revision-input-name=lxd-snap-revision --channel-input-name=lxd-snap-channel
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Checkout history with git tags
       - name: Set up environment

--- a/.github/workflows/build_rock.yaml
+++ b/.github/workflows/build_rock.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=python/cli
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Collect rock platforms to build from rockcraft.yaml
         id: collect
         run: collect-rock-platforms --directory='${{ inputs.path-to-rock-directory }}'
@@ -82,7 +82,7 @@ jobs:
         id: rockcraft-snap-version
         run: parse-snap-version --revision='${{ inputs.rockcraft-snap-revision }}' --channel='${{ inputs.rockcraft-snap-channel }}' --revision-input-name=rockcraft-snap-revision --channel-input-name=rockcraft-snap-channel
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up environment
         run: |
           sudo adduser "$USER" lxd

--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=python/cli
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Collect snap platforms to build from snapcraft.yaml
         id: collect
         run: collect-snap-platforms --directory='${{ inputs.path-to-snap-project-directory }}'
@@ -85,7 +85,7 @@ jobs:
         id: snapcraft-snap-version
         run: parse-snap-version --revision='${{ inputs.snapcraft-snap-revision }}' --channel='${{ inputs.snapcraft-snap-channel }}' --revision-input-name=snapcraft-snap-revision --channel-input-name=snapcraft-snap-channel
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up environment
         run: |
           sudo adduser "$USER" lxd

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -142,7 +142,7 @@ jobs:
           with open(os.environ["GITHUB_OUTPUT"], "a") as file:
               file.write(output)
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install tox & poetry
         run: |
           pipx install tox
@@ -293,7 +293,7 @@ jobs:
               file.write(output)
       - name: Checkout
         timeout-minutes: 3
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up environment
         timeout-minutes: 5
         run: |
@@ -543,7 +543,7 @@ jobs:
       # git push origin gh-pages-beta
       # )
       - name: Checkout GitHub pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: gh-pages-beta
           path: repo/

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install actionlint
         id: install
         run: |
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install tox & poetry
         run: |
           pipx install tox

--- a/.github/workflows/release_charm_edge.yaml
+++ b/.github/workflows/release_charm_edge.yaml
@@ -64,7 +64,7 @@ jobs:
         run: pipx install git+https://github.com/lucabello/noctua
       - run: snap list
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Compute path in artifact
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-charm-directory }}'

--- a/.github/workflows/release_charm_pr.yaml
+++ b/.github/workflows/release_charm_pr.yaml
@@ -61,7 +61,7 @@ jobs:
         run: pipx install git+https://github.com/lucabello/noctua
       - run: snap list
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Compute path in artifact
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-charm-directory }}'

--- a/.github/workflows/release_python_package_part1.yaml
+++ b/.github/workflows/release_python_package_part1.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=python/cli
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Checkout history with git tags
       - name: Create release tag
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Checkout history with git tags
       - name: Install poetry

--- a/.github/workflows/release_rock.yaml
+++ b/.github/workflows/release_rock.yaml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install skopeo -y
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/release_snap.yaml
+++ b/.github/workflows/release_snap.yaml
@@ -66,7 +66,7 @@ jobs:
         run: sudo snap install snapcraft --classic ${{ steps.snapcraft-snap-version.outputs.install_flag }}
       - run: snap list
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Compute path in artifact
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-snap-project-directory }}'

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Install CLI
       run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=python/cli
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Update Discourse docs
       run: sync-docs
     - name: Push `sync-docs` branch & create pull request

--- a/.github/workflows/tag_charm_edge.yaml
+++ b/.github/workflows/tag_charm_edge.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=python/cli
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Checkout history with git tags
       - name: Create git tag


### PR DESCRIPTION
Requires runner v2.327.1 or greater: https://github.com/actions/checkout/releases/tag/v5.0.0

May affect jobs with IS-hosted runners:
- build_*.yaml on s390x
- integration_test_charm.yaml