### PR TITLE
patch(_promote_charms.yaml): Add legacy support for charms without refresh compatibility version

### DIFF
--- a/.github/workflows/_promote_charms.md
+++ b/.github/workflows/_promote_charms.md
@@ -4,9 +4,11 @@ Workflow file: [_promote_charms.yaml](_promote_charms.yaml)
 > Subject to **breaking changes on patch release**. `_promote_charms.yaml` is experimental & not part of the public interface.
 
 ## Limitations
-This workflow currently only supports charms that implement in-place upgrades & rollbacks with [charm-refresh](https://github.com/canonical/charm-refresh) and, thus, use [tag_charm_edge.yaml](release_charm_edge.md).
+All charms must be released to the same track.
 
-All charms must be released to the same track. All charms must share an identical charm refresh compatibility version tag.
+For charms that implement in-place upgrades & rollbacks with [charm-refresh](https://github.com/canonical/charm-refresh), [tag_charm_edge.yaml](release_charm_edge.md) must be used and all charms must share an identical charm refresh compatibility version tag.
+
+(**deprecated**) For existing legacy tracks that do not have charm refresh compatibility version tags, the `deprecated-legacy-charms-without-charm-refresh-compatibility-version-tag` input can be used. Charms with charm refresh compatibility version tags and charms without cannot be mixed in the same git branch. For new tracks, [tag_charm_edge.yaml](release_charm_edge.md) must be used and this input must not be used.
 
 ## Usage
 ### Step 1: Add `promote.yaml` file to `.github/workflows/`

--- a/.github/workflows/_promote_charms.yaml
+++ b/.github/workflows/_promote_charms.yaml
@@ -26,6 +26,14 @@ on:
           Must be one of "beta", "candidate", "stable"
         required: true
         type: string
+      deprecated-legacy-charms-without-charm-refresh-compatibility-version-tag:
+        description: |
+          (deprecated) Charm(s) do not have charm refresh compatibility version tag
+
+          Only use this input for charms with an existing legacy track that does not have charm refresh compatibility version tags
+          For new tracks, use tag_charm_edge.yaml to create the tags and do not use this input. Usage docs: https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/release_charm_edge.md
+        default: false
+        type: boolean
       charmcraft-snap-revision:
         description: charmcraft snap revision
         required: false
@@ -75,7 +83,7 @@ jobs:
           fetch-depth: 0  # Checkout history with git tags
       - name: Promote charms
         id: promote
-        run: promote-charms --track='${{ inputs.track }}' --from-risk='${{ inputs.from-risk }}' --to-risk='${{ inputs.to-risk }}' --ref='${{ github.ref }}'
+        run: promote-charms --track='${{ inputs.track }}' --from-risk='${{ inputs.from-risk }}' --to-risk='${{ inputs.to-risk }}' --ref='${{ github.ref }}' --legacy-no-refresh-compatibility-tag='${{ toJSON(inputs.deprecated-legacy-charms-without-charm-refresh-compatibility-version-tag) }}'
         env:
           CHARMCRAFT_AUTH: ${{ secrets.charmhub-token }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Requested by @taurus-forever https://warthogs.atlassian.net/browse/DPE-8443

This will add significant complexity to & slow down future iteration of the experimental promote workflow(s), see https://github.com/canonical/data-platform-workflows/issues/313#issuecomment-3377212826 