### PR TITLE
patch: Adding Storage to lxd containers to fix OpenSearch yellow cluster state 

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -217,6 +217,11 @@ jobs:
           rm -r /opt/hostedtoolcache/
           printf '\nDisk usage after cleanup\n'
           df --human-readable
+      - name: (Github hosted) Mount /mnt to have more storage 
+        if: ${{ !matrix.groups.is_hosted }}
+        run: |
+          sudo mkdir -p /var/snap/lxd/common/lxd/storage-pools
+          sudo mount --bind /mnt /var/snap/lxd/common/lxd/storage-pools
       - name: (IS hosted) Disk usage
         timeout-minutes: 1
         if: ${{ matrix.groups.is_hosted }}
@@ -404,7 +409,7 @@ jobs:
             then
               sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:8de71f421b30 local: --alias 'juju/focal/amd64'
             else
-              sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:82b997ec581b local: --alias 'juju/ubuntu@22.04/amd64'
+              sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:568f69ff1166 local: --alias 'juju/ubuntu@22.04/amd64'
             fi
           else
             sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc image copy ubuntu:60d56aa663ed local: --alias 'juju/ubuntu@22.04/arm64'


### PR DESCRIPTION
This PR address the issue described in this ticket [DPE-8510](https://warthogs.atlassian.net/browse/DPE-8510?atlOrigin=eyJpIjoiMDg3M2IxMGY0NDdhNDljZGFlMjVlY2ZhMTFlYWJlYzQiLCJwIjoiaiJ9). After investigations it seems that the openSearch cluster don't have enough storage on both nodes in order to assign replica shards, and as result go on a yellow health state which make tests fails. 

This PR solves this issue by adding more storage to the lxd storage pools by mounting `/mnt`.  The solution has been tested by using a fork of this data-platform-workflows repository that you can check  [here](https://github.com/akram09/data-platform-workflows), then calling the workflow from the data-integrator repository workflows.  This is the [PoC ](https://github.com/canonical/data-integrator/actions/runs/18647978380/job/53191736853?pr=192). 

[DPE-8510]: https://warthogs.atlassian.net/browse/DPE-8510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ