### PR TITLE
breaking: Ensure `track` and `channel` inputs are not empty string

### DIFF
--- a/_cli/data_platform_workflows_cli/craft_tools/promote.py
+++ b/_cli/data_platform_workflows_cli/craft_tools/promote.py
@@ -359,6 +359,8 @@ def charms():
     charms_ = sorted(charms_, key=lambda charm: charm.name)
 
     track = args.track
+    if track == "":
+        raise ValueError("`track` input must not be empty string")
     if "/" in track:
         raise ValueError(f"`track` input cannot contain '/' character: {repr(track)}")
     from_risk = Risk.get(args.from_risk, direction=Direction.FROM)

--- a/_cli/data_platform_workflows_cli/craft_tools/release.py
+++ b/_cli/data_platform_workflows_cli/craft_tools/release.py
@@ -42,6 +42,10 @@ def snap():
     parser.add_argument("--create-tags", required=True)
     args = parser.parse_args()
     directory = pathlib.Path(args.directory)
+    channel = args.channel
+
+    if channel == "":
+        raise ValueError("`channel` input must not be empty string")
 
     snap_name = yaml.safe_load((directory / "snap/snapcraft.yaml").read_text())["name"]
 
@@ -56,7 +60,7 @@ def snap():
         # Example: "amd64"
         architecture = snap_file.name.removesuffix(".snap").split("_")[-1]
         logging.info(f"Uploading {snap_file=}")
-        output = run(["snapcraft", "upload", "--release", args.channel, snap_file])
+        output = run(["snapcraft", "upload", "--release", channel, snap_file])
         # Example `output`: "Revision 3 created for 'charmed-postgresql' and released to 'latest/edge'"
         match = re.match("Revision ([0-9]+) created for ", output)
         assert match, "Unable to parse revision"
@@ -163,7 +167,10 @@ def _charm(*, pr: bool):
     metadata_file = yaml.safe_load((directory / "metadata.yaml").read_text())
     charm_name = metadata_file["name"]
 
-    channel = f"{args.track}/edge"
+    track = args.track
+    if track == "":
+        raise ValueError("`track` input must not be empty string")
+    channel = f"{track}/edge"
     if pr:
         channel += f"/pr-{args.pr_number}"
 

--- a/_cli/data_platform_workflows_cli/create_charm_refresh_version_tag_edge.py
+++ b/_cli/data_platform_workflows_cli/create_charm_refresh_version_tag_edge.py
@@ -14,6 +14,9 @@ def main():
     args = parser.parse_args()
     track = args.track
 
+    if track == "":
+        raise ValueError("`track` input must not be empty string")
+
     charm_majors_by_path = {}
     charm_directories = []
     for path in pathlib.Path().glob("**/charmcraft.yaml"):


### PR DESCRIPTION
If empty string is passed to charmcraft, it will use default track—which is probably not expected by workflow user

Empty string can happen if GitHub Actions workflow expression is invalid

Prevent mistakes such as
https://github.com/canonical/mysql-router-operators/actions/runs/18686612734/job/53281752422?pr=51#step:11:1
https://github.com/canonical/mysql-router-operators/actions/runs/18686612734/workflow?pr=51#L88