### PR TITLE
breaking: Update download-artifact and upload-artifact

### DIFF
--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -159,7 +159,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-charm-directory }}'
       - name: Upload charm package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-${{ matrix.platform.name_in_artifact }}
           # .empty file required to preserve directory structure

--- a/.github/workflows/build_rock.yaml
+++ b/.github/workflows/build_rock.yaml
@@ -107,7 +107,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-rock-directory }}'
       - name: Upload rock package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-${{ matrix.platform.name }}
           # .empty file required to preserve directory structure

--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -110,7 +110,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-snap-project-directory }}'
       - name: Upload snap package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-${{ matrix.platform.name }}
           # .empty file required to preserve directory structure

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -181,7 +181,7 @@ jobs:
         # Default test results in case the integration tests time out or runner set up fails
         # (So that Allure report will show "unknown"/"failed" test result, instead of omitting the test)
         if: ${{ inputs._beta_allure_report && github.event_name == 'schedule' && github.run_attempt == '1' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           # TODO future improvement: ensure artifact name is unique (if called with a matrix that changes inputs)
           name: allure-collection-default-results-integration-test-charm
@@ -344,7 +344,7 @@ jobs:
         run: time curl -s -L -v -o charmed-postgresql_133.snap https://api.snapcraft.io/api/v1/snaps/download/mAiAP9VqaDs9TXjjb9RpIULHkYwb9IoH_133.snap > curl_debug.log 2>&1
       - name: Upload snap download logs for debugging
         timeout-minutes: 5
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: debug-logs-snap-download-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || steps.parse-versions.outputs.snap_channel_for_artifact }}-${{ inputs.architecture }}-${{ matrix.groups.artifact_group_id }}
           path: curl_debug.log
@@ -380,7 +380,7 @@ jobs:
       - name: Upload microk8s logs for debugging
         timeout-minutes: 5
         if: ${{ failure() && steps.microk8s-setup.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: debug-logs-microk8s-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || steps.parse-versions.outputs.snap_channel_for_artifact }}-${{ inputs.architecture }}-${{ matrix.groups.artifact_group_id }}
           path: /var/snap/microk8s/current/inspection-report-*.tar.gz
@@ -432,7 +432,7 @@ jobs:
         run: poetry add --lock --group integration juju@'${{ inputs.libjuju-version-constraint }}'
       - name: Download packed charm(s)
         timeout-minutes: 5
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
@@ -474,7 +474,7 @@ jobs:
       - name: (beta) Upload Allure results
         timeout-minutes: 3
         if: ${{ (success() || (failure() && steps.tests.outcome == 'failure')) && inputs._beta_allure_report && github.event_name == 'schedule' && github.run_attempt == '1' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: allure-results-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || steps.parse-versions.outputs.snap_channel_for_artifact }}-${{ inputs.architecture }}-${{ matrix.groups.artifact_group_id }}
           path: allure-results/
@@ -494,7 +494,7 @@ jobs:
       - name: Upload logs
         timeout-minutes: 5
         if: ${{ success() || (failure() && steps.tests.outcome == 'failure') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: logs-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || steps.parse-versions.outputs.snap_channel_for_artifact }}-${{ inputs.architecture }}-${{ matrix.groups.artifact_group_id }}
           path: ~/logs/
@@ -550,12 +550,12 @@ jobs:
       - name: Download default test collection results
         # Default test results in case the integration tests time out or runner set up fails
         # (So that Allure report will show "unknown"/"failed" test result, instead of omitting the test)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           path: allure-collection-default-results/
           name: allure-collection-default-results-integration-test-charm
       - name: Download test results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           path: allure-results/
           pattern: allure-results-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || needs.integration-test.outputs.juju-snap-channel-for-artifact }}-${{ inputs.architecture }}-*

--- a/.github/workflows/release_charm_edge.yaml
+++ b/.github/workflows/release_charm_edge.yaml
@@ -69,7 +69,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-charm-directory }}'
       - name: Download charm package(s)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true

--- a/.github/workflows/release_charm_pr.yaml
+++ b/.github/workflows/release_charm_pr.yaml
@@ -66,7 +66,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-charm-directory }}'
       - name: Download charm package(s)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true

--- a/.github/workflows/release_python_package.md
+++ b/.github/workflows/release_python_package.md
@@ -56,7 +56,7 @@ jobs:
     environment: production
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: ${{ needs.release-part1.outputs.artifact-name }}
           path: dist/

--- a/.github/workflows/release_python_package_part1.yaml
+++ b/.github/workflows/release_python_package_part1.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Build package
         run: poetry build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: python-package-distributions  # Keep in sync with `artifact-name` output
           path: dist/

--- a/.github/workflows/release_rock.yaml
+++ b/.github/workflows/release_rock.yaml
@@ -53,7 +53,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-rock-directory }}'
       - name: Download rock package(s)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true

--- a/.github/workflows/release_snap.yaml
+++ b/.github/workflows/release_snap.yaml
@@ -71,7 +71,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-snap-project-directory }}'
       - name: Download snap package(s)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true


### PR DESCRIPTION
download-artifact v6 and upload-artifact v5 appear to support but not require node24 (different from checkout v5 which required node24 https://github.com/canonical/data-platform-workflows/pull/303)

Upstream says "This is not a breaking change per-se but we're treating it as such." so unclear if this is a breaking change
https://github.com/actions/download-artifact/releases/tag/v6.0.0
https://github.com/actions/upload-artifact/releases/tag/v5.0.0