### PR TITLE
breaking(build_*.yaml): Use PS7 runners for s390x

### DIFF
--- a/_cli/data_platform_workflows_cli/craft_tools/collect_platforms.py
+++ b/_cli/data_platform_workflows_cli/craft_tools/collect_platforms.py
@@ -26,8 +26,7 @@ logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 RUNNERS = {
     craft.Architecture.X64: "ubuntu-latest",
     craft.Architecture.ARM64: "ubuntu-24.04-arm",
-    # Use PS6 runners while PS7 runners unstable: https://chat.canonical.com/canonical/pl/3wcxtsrzo3ykdxe6rzp5uuus8h
-    craft.Architecture.S390X: "self-hosted-linux-s390x-noble-edge",
+    craft.Architecture.S390X: "self-hosted-linux-s390x-noble-medium",
 }
 
 


### PR DESCRIPTION
Use PS7 reactive runners which have a limit of 22 concurrent runners (https://chat.canonical.com/canonical/pl/5de45zoe9tfmudiw8hfxmgrsrw) instead of PS6 runners which have a limit of 3 concurrent runners

PS7 s390x runners appear to have been fixed with a new tenant https://chat.canonical.com/canonical/pl/up7jwo31rf84mgywfr8x63urty