### PR TITLE
breaking(release_python_package.yaml): Only mark GitHub release as latest on default branch

### DIFF
--- a/.github/workflows/_promote_charm_legacy.yaml
+++ b/.github/workflows/_promote_charm_legacy.yaml
@@ -75,7 +75,7 @@ jobs:
           fetch-depth: 0  # Checkout history with git tags
       - name: Promote charm
         id: promote
-        run: promote-charm-legacy --track='${{ inputs.track }}' --from-risk='${{ inputs.from-risk }}' --to-risk='${{ inputs.to-risk }}' --ref='${{ github.ref }}'
+        run: promote-charm-legacy --track='${{ inputs.track }}' --from-risk='${{ inputs.from-risk }}' --to-risk='${{ inputs.to-risk }}' --ref='${{ github.ref }}' --default-branch='${{ github.event.repository.default_branch }}'
         env:
           CHARMCRAFT_AUTH: ${{ secrets.charmhub-token }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_promote_charms.yaml
+++ b/.github/workflows/_promote_charms.yaml
@@ -75,7 +75,7 @@ jobs:
           fetch-depth: 0  # Checkout history with git tags
       - name: Promote charms
         id: promote
-        run: promote-charms --track='${{ inputs.track }}' --from-risk='${{ inputs.from-risk }}' --to-risk='${{ inputs.to-risk }}' --ref='${{ github.ref }}'
+        run: promote-charms --track='${{ inputs.track }}' --from-risk='${{ inputs.from-risk }}' --to-risk='${{ inputs.to-risk }}' --ref='${{ github.ref }}' --default-branch='${{ github.event.repository.default_branch }}'
         env:
           CHARMCRAFT_AUTH: ${{ secrets.charmhub-token }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_python_package_part2.yaml
+++ b/.github/workflows/release_python_package_part2.yaml
@@ -16,6 +16,25 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Create GitHub release
-        run: gh release --repo '${{ github.repository }}' create '${{ inputs.git-tag }}' --verify-tag --generate-notes
+        # GitHub CLI docs on `--latest` are incorrect; default is to always mark release as latest
+        # https://github.com/cli/cli/blob/85d6766c621a9d67e0d353a12bb388c40ceca2a1/pkg/cmd/release/create/create.go#L217
+        # https://github.com/cli/cli/blob/85d6766c621a9d67e0d353a12bb388c40ceca2a1/pkg/cmdutil/flags.go#L23
+        # (default is not automatic, as written in the CLI docs)
+        # The actual behavior matches the default value for `make_latest` in the GitHub API:
+        # https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
+        # Furthermore, the automatic behavior (when setting `make_latest` to `legacy` and calling
+        # the API directly), from testing, appears to only work with semantic versions—otherwise
+        # the ordering appears to be alphabetical (so it sees "v1.0.0.2" as a newer version than
+        # "v1.0.0.10")
+        # Instead, determine if this is the latest version by whether this branch is the default
+        # branch
+        run: |
+          # Check if this branch is the default branch for the GitHub repository
+          if [[ '${{ github.ref }}' == 'refs/heads/${{ github.event.repository.default_branch }}' ]]
+          then
+            gh release --repo '${{ github.repository }}' create '${{ inputs.git-tag }}' --verify-tag --generate-notes --latest
+          else
+            gh release --repo '${{ github.repository }}' create '${{ inputs.git-tag }}' --verify-tag --generate-notes --latest=false
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Breaking change for release_python_package.yaml, _promote_charms.yaml, and _promote_charm_legacy.yaml

Previously, thought that the latest release was being determined automatically, per GitHub CLI docs (https://cli.github.com/manual/gh_release_create)

However, GitHub CLI docs on `--latest` are incorrect; default is to always mark release as latest
https://github.com/cli/cli/blob/85d6766c621a9d67e0d353a12bb388c40ceca2a1/pkg/cmd/release/create/create.go#L217
https://github.com/cli/cli/blob/85d6766c621a9d67e0d353a12bb388c40ceca2a1/pkg/cmdutil/flags.go#L23
The actual behavior matches the default value for `make_latest` in the GitHub API: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release

Instead of relying on the GitHub CLI to determine if the release should be marked as latest, determine ourselves by checking if the branch that is being released/promoted is the default branch

Alternatively, we could call the API directly and set `make_latest` to `legacy`. However, from testing, this appears to only work with semantic versions (i.e. not charm refresh compatibility versions)—otherwise the ordering appears to be alphabetical (so it sees "v1.0.0.2" as a newer version than "v1.0.0.10"). However, this behavior is not documented so the behavior could be more complex