### PR TITLE
patch: ensure craft artifacts are downloaded in specified path

### DIFF
--- a/.github/workflows/release_charm_edge.yaml
+++ b/.github/workflows/release_charm_edge.yaml
@@ -73,6 +73,7 @@ jobs:
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true
+          path: ${{ inputs.path-to-charm-directory }}
       - name: Upload & release charm
         id: release
         run: release-charm-edge --directory='${{ inputs.path-to-charm-directory }}' --track='${{ inputs.track }}'

--- a/.github/workflows/release_charm_pr.yaml
+++ b/.github/workflows/release_charm_pr.yaml
@@ -70,6 +70,7 @@ jobs:
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true
+          path: ${{ inputs.path-to-charm-directory }}
       - name: Upload & release charm
         id: release
         run: release-charm-pr --directory='${{ inputs.path-to-charm-directory }}' --track='${{ inputs.track }}' --pr='${{ github.event.pull_request.number }}'

--- a/.github/workflows/release_rock.yaml
+++ b/.github/workflows/release_rock.yaml
@@ -57,6 +57,7 @@ jobs:
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true
+          path: ${{ inputs.path-to-rock-directory }}
       - name: Upload & release rock
         id: release
         run: release-rock --directory='${{ inputs.path-to-rock-directory }}' --create-tags='${{ inputs.create-git-tags }}'

--- a/.github/workflows/release_snap.yaml
+++ b/.github/workflows/release_snap.yaml
@@ -75,6 +75,7 @@ jobs:
         with:
           pattern: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-*
           merge-multiple: true
+          path: ${{ inputs.path-to-snap-project-directory }}
       - name: Upload & release snap
         id: release
         run: release-snap --directory='${{ inputs.path-to-snap-project-directory }}' --channel='${{ inputs.channel }}' --create-tags='${{ inputs.create-git-tags }}'


### PR DESCRIPTION
When `path-to-<artifact>-directory` is specified, the release tool will look for the artifact inside the specified directory. The download-artifact should download the built rocks inside this directory.

fix: #329 