### PR TITLE
patch(build_*.yaml): Include `.empty` in artifact upload

### DIFF
--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -167,4 +167,5 @@ jobs:
           path: |
             ${{ inputs.path-to-charm-directory }}/*.charm
             .empty
+          include-hidden-files: true  # For `.empty`
           if-no-files-found: error

--- a/.github/workflows/build_rock.yaml
+++ b/.github/workflows/build_rock.yaml
@@ -115,4 +115,5 @@ jobs:
           path: |
             ${{ inputs.path-to-rock-directory }}/*.rock
             .empty
+          include-hidden-files: true  # For `.empty`
           if-no-files-found: error

--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -118,4 +118,5 @@ jobs:
           path: |
             ${{ inputs.path-to-snap-project-directory }}/*.snap
             .empty
+          include-hidden-files: true  # For `.empty`
           if-no-files-found: error


### PR DESCRIPTION
actions/upload-artifact 4.4 made a breaking change (without bumping major version, so we didn't see this in their release notes) to exclude hidden files by default: https://github.com/actions/upload-artifact/pull/598

It appears that our `.empty` usage to preserve the directory structure in the artifact still works, despite the `.empty` file no longer being uploaded to the artifact (from testing on https://github.com/canonical/mysql-router-operators/pull/73)
https://github.com/canonical/data-platform-workflows/blob/549b516a1f065b8ee367913b996048a58100cb47/.github/workflows/build_charm.yaml#L161-L170

However, it doesn't seem like a good idea to rely on this behavior—it seems like this might change in the future since `.empty` is not being uploaded to the artifact

Include the `.empty` file in the artifact to restore behavior to < 4.4 and to reduce the likelihood of this breaking in the future