### PR TITLE
patch(release_rock.yaml): Use absolute path with skopeo

### DIFF
--- a/_cli/data_platform_workflows_cli/craft_tools/release.py
+++ b/_cli/data_platform_workflows_cli/craft_tools/release.py
@@ -100,7 +100,7 @@ def rock():
             [
                 "skopeo",
                 "inspect",
-                f"oci-archive:{rock_file.name}",
+                f"oci-archive:{str(rock_file.absolute())}",
                 "--format",
                 "{{ .Digest }}",
             ]
@@ -110,7 +110,7 @@ def rock():
             [
                 "skopeo",
                 "copy",
-                f"oci-archive:{rock_file.name}",
+                f"oci-archive:{str(rock_file.absolute())}",
                 f"docker://ghcr.io/canonical/{yaml_data['name']}@{digest}",
             ]
         )


### PR DESCRIPTION
Fixes #329