### PR TITLE
breaking(build_snap.yaml): Add build manifest.

### DIFF
--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         platform: ${{ fromJSON(needs.collect-platforms.outputs.platforms) }}
-    name: "Build snap | ${{ matrix.platform.name }}"
+    name: 'Build snap | ${{ matrix.platform.name }}'
     needs:
       - collect-platforms
     runs-on: ${{ matrix.platform.runner }}
@@ -123,5 +123,5 @@ jobs:
           path: |
             ${{ inputs.path-to-snap-project-directory }}/*.snap
             .empty
-          include-hidden-files: true # For `.empty`
+          include-hidden-files: true  # For `.empty`
           if-no-files-found: error


### PR DESCRIPTION
This PR adds an environment variable in the snapcraft pack call. This allows to add the build manifest in `snap/manifest.yaml`. This contains the specific sources and packages used to build the snap and allows the Snap Store to automatically check your snap for security issues.

This is a requirement from the security team.

cf [documentation](https://documentation.ubuntu.com/snapcraft/stable/reference/build-environment-options/)