### PR TITLE
patch(release_snap.yaml): Increase timeout

### DIFF
--- a/.github/workflows/release_snap.yaml
+++ b/.github/workflows/release_snap.yaml
@@ -48,7 +48,7 @@ jobs:
   release-snap:
     name: Release snap
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Get workflow version
         id: workflow-version


### PR DESCRIPTION
Snap store has been slow recently
e.g.
https://github.com/canonical/mysql-snap/actions/runs/21991699302/job/63541387338
https://github.com/canonical/postgresql-snap/actions/runs/21980794357/job/63504867880