### PR TITLE
patch: Move CODEOWNERS to .github/ directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @delgod @taurus-forever @Mehdi-Bendriss @marcoppenheimer @paulomach @carlcsaposs-canonical @akram09 @reneradoi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*             @delgod @taurus-forever @Mehdi-Bendriss @marcoppenheimer @paulomach @carlcsaposs-canonical @akram09 @reneradoi


### PR DESCRIPTION
To make the root repository directory a bit cleaner