### PR TITLE
breaking: Add explicit permissions to workflows

### DIFF
--- a/.github/workflows/__check_pr.yaml
+++ b/.github/workflows/__check_pr.yaml
@@ -14,3 +14,5 @@ jobs:
   check-pr:
     name: Check pull request
     uses: ./.github/workflows/check_python_package_pr.yaml
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version

--- a/.github/workflows/__lint.yaml
+++ b/.github/workflows/__lint.yaml
@@ -22,3 +22,5 @@ jobs:
       - name: Run actionlint
         run: |
           '${{ steps.install.outputs.executable }}' -color
+    permissions:
+      contents: read

--- a/.github/workflows/_mirror_charm.md
+++ b/.github/workflows/_mirror_charm.md
@@ -27,6 +27,8 @@ jobs:
       repository: ${{ matrix.charm.repo }}
     secrets:
       token: ${{ secrets.MIRROR_REPOS_PAT }}
+    permissions:
+      contents: read
 ```
 
 ### metadata.yaml required

--- a/.github/workflows/_mirror_charm.yaml
+++ b/.github/workflows/_mirror_charm.yaml
@@ -35,3 +35,5 @@ jobs:
       - name: Mirror charm
         working-directory: ${{ inputs.path-to-charm-directory }}
         run: charmcraftlocal mirror '${{ inputs.repository }}' -v
+    permissions:
+      contents: read

--- a/.github/workflows/_promote_charm_legacy.md
+++ b/.github/workflows/_promote_charm_legacy.md
@@ -46,6 +46,7 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to edit GitHub releases
 ```
 ### Step 2: Add `check_pr.yaml` file to `.github/workflows/`
@@ -68,6 +69,7 @@ jobs:
   check-pr:
     name: Check pull request
     uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@v0.0.0
+    permissions: {}
 ```
 Update `branches` to include all branches that [`release_charm_edge.yaml`](release_charm_edge.md) runs on
 

--- a/.github/workflows/_promote_charm_legacy.yaml
+++ b/.github/workflows/_promote_charm_legacy.yaml
@@ -82,3 +82,6 @@ jobs:
       - name: Charmcraft logs
         if: ${{ success() || (failure() && steps.promote.outcome == 'failure') }}
         run: cat ~/.local/state/charmcraft/log/*
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: write  # Needed to edit GitHub releases

--- a/.github/workflows/_promote_charms.md
+++ b/.github/workflows/_promote_charms.md
@@ -46,6 +46,7 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to edit GitHub releases
 ```
 ### Step 2: Add `check_pr.yaml` file to `.github/workflows/`
@@ -67,6 +68,7 @@ jobs:
   check-pr:
     name: Check pull request
     uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@v0.0.0
+    permissions: {}
 ```
 Update `branches` to include all branches that [`release_charm_edge.yaml`](release_charm_edge.md) runs on
 

--- a/.github/workflows/_promote_charms.yaml
+++ b/.github/workflows/_promote_charms.yaml
@@ -82,3 +82,6 @@ jobs:
       - name: Charmcraft logs
         if: ${{ success() || (failure() && steps.promote.outcome == 'failure') }}
         run: cat ~/.local/state/charmcraft/log/*
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: write  # Needed to edit GitHub releases

--- a/.github/workflows/_update_bundle.md
+++ b/.github/workflows/_update_bundle.md
@@ -23,4 +23,8 @@ jobs:
       reviewers: canonical/data-platform-engineers,octocat
     secrets:
       token: ${{ secrets.CREATE_PR_APP_TOKEN }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: write  # Needed to push branch
+      pull-requests: write  # Needed to create PR
 ```

--- a/.github/workflows/_update_bundle.yaml
+++ b/.github/workflows/_update_bundle.yaml
@@ -78,3 +78,7 @@ jobs:
           gh pr create --head update-bundle --title "Update bundle" --body "Update charm revisions in bundle YAML file" --reviewer '${{ inputs.reviewers }}'
         env:
           GH_TOKEN: ${{ secrets.token }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: write  # Needed to push branch
+      pull-requests: write  # Needed to create PR

--- a/.github/workflows/approve_renovate_pr.yaml
+++ b/.github/workflows/approve_renovate_pr.yaml
@@ -12,3 +12,5 @@ jobs:
         run: gh pr --repo '${{ github.repository }}' review '${{ github.event.pull_request.number }}' --approve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      pull-requests: write  # Needed to approve PR

--- a/.github/workflows/build_charm.md
+++ b/.github/workflows/build_charm.md
@@ -8,6 +8,9 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v0.0.0
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 ```
 
 Unless you disable caching (with `cache: false`), remember to add your charm's branch(es) to charmcraftcache: https://github.com/canonical/charmcraftcache?tab=readme-ov-file#usage

--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -77,6 +77,9 @@ jobs:
         run: collect-charm-platforms --directory='${{ inputs.path-to-charm-directory }}'
     outputs:
       platforms: ${{ steps.collect.outputs.platforms }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: read
 
   build:
     strategy:
@@ -171,3 +174,6 @@ jobs:
             .empty
           include-hidden-files: true  # For `.empty`
           if-no-files-found: error
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: read

--- a/.github/workflows/build_rock.md
+++ b/.github/workflows/build_rock.md
@@ -8,6 +8,9 @@ jobs:
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v0.0.0
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 ```
 
 ### Supported `platforms` syntax in rockcraft.yaml

--- a/.github/workflows/build_rock.yaml
+++ b/.github/workflows/build_rock.yaml
@@ -73,6 +73,9 @@ jobs:
         run: collect-rock-platforms --directory='${{ inputs.path-to-rock-directory }}'
     outputs:
       platforms: ${{ steps.collect.outputs.platforms }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: read
 
   build:
     strategy:
@@ -151,3 +154,6 @@ jobs:
             .empty
           include-hidden-files: true  # For `.empty`
           if-no-files-found: error
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: read

--- a/.github/workflows/build_snap.md
+++ b/.github/workflows/build_snap.md
@@ -8,6 +8,9 @@ jobs:
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v0.0.0
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 ```
 
 ### Supported `platforms` and `architectures` syntax in snapcraft.yaml

--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -76,6 +76,9 @@ jobs:
         run: collect-snap-platforms --directory='${{ inputs.path-to-snap-project-directory }}'
     outputs:
       platforms: ${{ steps.collect.outputs.platforms }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: read
 
   build:
     strategy:
@@ -156,3 +159,6 @@ jobs:
             .empty
           include-hidden-files: true  # For `.empty`
           if-no-files-found: error
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: read

--- a/.github/workflows/check_charm_pr.yaml
+++ b/.github/workflows/check_charm_pr.yaml
@@ -32,3 +32,4 @@ jobs:
         # Use env variable to avoid script injection & accept multi-line strings
         env:
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+    permissions: {}

--- a/.github/workflows/check_python_package_pr.yaml
+++ b/.github/workflows/check_python_package_pr.yaml
@@ -21,3 +21,5 @@ jobs:
         # Use env variable to avoid script injection
         env:
           TITLE: ${{ github.event.pull_request.title }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)

--- a/.github/workflows/lint.md
+++ b/.github/workflows/lint.md
@@ -8,4 +8,6 @@ jobs:
   lint:
     name: Lint
     uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v0.0.0
+    permissions:
+      contents: read
 ```

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,6 +23,8 @@ jobs:
       - name: Run actionlint
         run: |
           '${{ steps.install.outputs.executable }}' -color
+    permissions:
+      contents: read
 
   tox-lint:
     name: tox run -e lint
@@ -37,3 +39,5 @@ jobs:
           pipx install poetry
       - name: Run linters
         run: tox run -e lint
+    permissions:
+      contents: read

--- a/.github/workflows/release_charm_edge.md
+++ b/.github/workflows/release_charm_edge.md
@@ -21,6 +21,7 @@ jobs:
     with:
       track: 'latest'
     permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to create git tag
   
   build:
@@ -28,6 +29,9 @@ jobs:
     needs:
       - tag
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v0.0.0
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 
   release:
     name: Release charm
@@ -41,6 +45,7 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to create git tags
 ```
 

--- a/.github/workflows/release_charm_edge.yaml
+++ b/.github/workflows/release_charm_edge.yaml
@@ -82,3 +82,6 @@ jobs:
       - name: Charmcraft logs
         if: ${{ success() || (failure() && steps.release.outcome == 'failure') }}
         run: cat ~/.local/state/charmcraft/log/*
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: write  # Needed to create git tags

--- a/.github/workflows/release_charm_pr.md
+++ b/.github/workflows/release_charm_pr.md
@@ -11,6 +11,9 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v0.0.0
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 
   release:
     name: Release charm to Charmhub branch
@@ -22,6 +25,9 @@ jobs:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 ```
 
 ### metadata.yaml required

--- a/.github/workflows/release_charm_pr.yaml
+++ b/.github/workflows/release_charm_pr.yaml
@@ -79,3 +79,6 @@ jobs:
       - name: Charmcraft logs
         if: ${{ success() || (failure() && steps.release.outcome == 'failure') }}
         run: cat ~/.local/state/charmcraft/log/*
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: read

--- a/.github/workflows/release_python_package.md
+++ b/.github/workflows/release_python_package.md
@@ -44,6 +44,7 @@ jobs:
     name: Release to PyPI (part 1)
     uses: canonical/data-platform-workflows/.github/workflows/release_python_package_part1.yaml@v0.0.0
     permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to create git tag
 
   # Separate job needed to workaround https://github.com/pypi/warehouse/issues/11096
@@ -95,6 +96,8 @@ jobs:
   check-pr:
     name: Check pull request
     uses: canonical/data-platform-workflows/.github/workflows/check_python_package_pr.yaml@v0.0.0
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
 ```
 
 ### Step 4: Configure GitHub repository settings

--- a/.github/workflows/release_python_package_part1.yaml
+++ b/.github/workflows/release_python_package_part1.yaml
@@ -32,6 +32,9 @@ jobs:
         run: create-semantic-version-tag
     outputs:
       tag: ${{ steps.create-tag.outputs.tag }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: write  # Needed to create git tag
   
   build:
     name: Build package
@@ -55,3 +58,5 @@ jobs:
         with:
           name: python-package-distributions  # Keep in sync with `artifact-name` output
           path: dist/
+    permissions:
+      contents: read

--- a/.github/workflows/release_python_package_part2.yaml
+++ b/.github/workflows/release_python_package_part2.yaml
@@ -31,3 +31,5 @@ jobs:
         run: gh release --repo '${{ github.repository }}' create '${{ inputs.git-tag }}' --verify-tag --generate-notes ${{ case(github.ref_name == github.event.repository.default_branch && startsWith(github.ref, 'refs/heads/'), '--latest', '--latest=false') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write  # Needed to create GitHub release

--- a/.github/workflows/release_rock.md
+++ b/.github/workflows/release_rock.md
@@ -20,6 +20,9 @@ jobs:
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v0.0.0
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 
   release:
     name: Release rock
@@ -29,6 +32,7 @@ jobs:
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
       packages: write  # Needed to publish to GitHub Container Registry
       contents: write  # Needed to create git tags
 ```

--- a/.github/workflows/release_rock.yaml
+++ b/.github/workflows/release_rock.yaml
@@ -62,3 +62,7 @@ jobs:
         run: release-rock --directory='${{ inputs.path-to-rock-directory }}' --create-tags='${{ inputs.create-git-tags }}'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      packages: write  # Needed to publish to GitHub Container Registry
+      contents: write  # Needed to create git tags

--- a/.github/workflows/release_snap.md
+++ b/.github/workflows/release_snap.md
@@ -20,6 +20,9 @@ jobs:
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v0.0.0
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 
   release:
     name: Release snap
@@ -32,6 +35,7 @@ jobs:
     secrets:
       snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}
     permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to create git tags
 ```
 

--- a/.github/workflows/release_snap.yaml
+++ b/.github/workflows/release_snap.yaml
@@ -85,3 +85,6 @@ jobs:
       - name: Snapcraft logs
         if: ${{ success() || (failure() && steps.release.outcome == 'failure') }}
         run: cat ~/.local/state/snapcraft/log/*
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: write  # Needed to create git tags

--- a/.github/workflows/sync_docs.md
+++ b/.github/workflows/sync_docs.md
@@ -23,6 +23,7 @@ jobs:
     with:
       reviewers: canonical/data-platform-technical-authors,octocat
     permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to push branch & tag
       pull-requests: write  # Needed to create PR
 ```

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -60,3 +60,7 @@ jobs:
         gh pr create --head sync-docs --title "Sync docs from Discourse" --body "Sync charm docs from https://discourse.charmhub.io" --label 'not bug or enhancement' --reviewer '${{ inputs.reviewers }}'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: write  # Needed to push branch & tag
+      pull-requests: write  # Needed to create PR

--- a/.github/workflows/tag_charm_edge.yaml
+++ b/.github/workflows/tag_charm_edge.yaml
@@ -31,3 +31,6 @@ jobs:
           fetch-depth: 0  # Checkout history with git tags
       - name: Create git tag
         run: create-charm-version-tag-edge --track='${{ inputs.track }}'
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: write  # Needed to create git tag


### PR DESCRIPTION
- Add `permissions` to reusable workflow internal jobs to drop to minimal permissions (for GITHUB_TOKEN), regardless of permissions set by the caller repository
- Update usage docs examples to call reusable workflows with minimal permissions
- Set minimal `permissions` for data-platform-workflows repository internal workflows (workflows beginning with two underscores in file name)

Breaking change since `contents: read` and `actions: read` permissions were added to some workflows (which requires caller to add those permissions)—it is not needed for public repositories, but is necessary for the workflows to succeed on private repositories. In order to drop to minimal permissions on the reusable workflows (e.g. so that other permission scopes are `none`) we have to set these on both public & private repositories. It might be possible to dynamically set this—but since these are read-only scopes, there is minimal additional risk—so it does not seem worth additional complexity to avoid the additional scopes for public repos only. Furthermore, for public repositories, it appears these read-only scopes do not grant additional permissions since the endpoints appear to already be available without authentication for public repositories: https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents, https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-actions

## Migration instructions
For each reusable workflow, check the usage docs (https://github.com/canonical/data-platform-workflows?tab=readme-ov-file#usage) and, for each workflow call, update `permissions` to match the usage docs