### PR TITLE
patch: Set `persist-credentials` for actions/checkout usage

### DIFF
--- a/.github/workflows/__lint.yaml
+++ b/.github/workflows/__lint.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install actionlint
         id: install
         run: |

--- a/.github/workflows/__release.yaml
+++ b/.github/workflows/__release.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: true
           fetch-depth: 0  # Checkout history with git tags
       - name: Install CLI
         run: pipx install ./_cli

--- a/.github/workflows/_mirror_charm.yaml
+++ b/.github/workflows/_mirror_charm.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: true
           fetch-depth: 0  # Checkout history with git tags
           token: ${{ secrets.token }}  # Token used during `git push` in `charmcraftlocal mirror`
       - name: Mirror charm

--- a/.github/workflows/_promote_charm_legacy.yaml
+++ b/.github/workflows/_promote_charm_legacy.yaml
@@ -72,6 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0  # Checkout history with git tags
       - name: Promote charm
         id: promote

--- a/.github/workflows/_promote_charms.yaml
+++ b/.github/workflows/_promote_charms.yaml
@@ -72,6 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           fetch-depth: 0  # Checkout history with git tags
       - name: Promote charms
         id: promote

--- a/.github/workflows/_update_bundle.yaml
+++ b/.github/workflows/_update_bundle.yaml
@@ -51,6 +51,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: true
           token: ${{ secrets.token }}
       - name: Update bundle file
         id: update-file

--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -72,6 +72,8 @@ jobs:
         run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=_cli
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Collect charm platforms to build from charmcraft.yaml
         id: collect
         run: collect-charm-platforms --directory='${{ inputs.path-to-charm-directory }}'
@@ -115,6 +117,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           fetch-depth: 0  # Checkout history with git tags
       # Needed to install poetry on s390x
       - name: (IS hosted) Install rust toolchain

--- a/.github/workflows/build_rock.yaml
+++ b/.github/workflows/build_rock.yaml
@@ -68,6 +68,8 @@ jobs:
         run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=_cli
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Collect rock platforms to build from rockcraft.yaml
         id: collect
         run: collect-rock-platforms --directory='${{ inputs.path-to-rock-directory }}'
@@ -110,6 +112,8 @@ jobs:
         run: parse-snap-version --revisions='${{ inputs.lxd-snap-revisions }}' --channel='${{ inputs.lxd-snap-channel }}' --revision-input-name=lxd-snap-revisions --channel-input-name=lxd-snap-channel
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Set up environment
         run: |
           sudo snap install lxd ${{ steps.lxd-snap-version.outputs.install_flag }}

--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -71,6 +71,8 @@ jobs:
         run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=_cli
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Collect snap platforms to build from snapcraft.yaml
         id: collect
         run: collect-snap-platforms --directory='${{ inputs.path-to-snap-project-directory }}'
@@ -113,6 +115,8 @@ jobs:
         run: parse-snap-version --revisions='${{ inputs.lxd-snap-revisions }}' --channel='${{ inputs.lxd-snap-channel }}' --revision-input-name=lxd-snap-revisions --channel-input-name=lxd-snap-channel
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Set up environment
         run: |
           sudo snap install lxd ${{ steps.lxd-snap-version.outputs.install_flag }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install actionlint
         id: install
         run: |
@@ -33,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install tox & poetry
         run: |
           pipx install tox

--- a/.github/workflows/release_charm_edge.yaml
+++ b/.github/workflows/release_charm_edge.yaml
@@ -65,6 +65,8 @@ jobs:
       - run: snap list
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: true
       - name: Compute path in artifact
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-charm-directory }}'

--- a/.github/workflows/release_charm_pr.yaml
+++ b/.github/workflows/release_charm_pr.yaml
@@ -62,6 +62,8 @@ jobs:
       - run: snap list
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Compute path in artifact
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-charm-directory }}'

--- a/.github/workflows/release_python_package_part1.yaml
+++ b/.github/workflows/release_python_package_part1.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: true
           fetch-depth: 0  # Checkout history with git tags
       - name: Create release tag
         id: create-tag
@@ -46,6 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           fetch-depth: 0  # Checkout history with git tags
       - name: Install poetry
         run: |

--- a/.github/workflows/release_rock.yaml
+++ b/.github/workflows/release_rock.yaml
@@ -43,6 +43,8 @@ jobs:
           sudo apt-get install skopeo -y
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: true
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/release_snap.yaml
+++ b/.github/workflows/release_snap.yaml
@@ -67,6 +67,8 @@ jobs:
       - run: snap list
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: true
       - name: Compute path in artifact
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-snap-project-directory }}'

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -27,6 +27,8 @@ jobs:
       run: pipx install git+https://github.com/canonical/data-platform-workflows@'${{ steps.workflow-version.outputs.sha }}'#subdirectory=_cli
     - name: Checkout
       uses: actions/checkout@v5
+      with:
+        persist-credentials: true
     - name: Update Discourse docs
       run: sync-docs
     - name: Push `sync-docs` branch & create pull request

--- a/.github/workflows/tag_charm_edge.yaml
+++ b/.github/workflows/tag_charm_edge.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: true
           fetch-depth: 0  # Checkout history with git tags
       - name: Create git tag
         run: create-charm-version-tag-edge --track='${{ inputs.track }}'


### PR DESCRIPTION
Explicitly set `persist-credentials` for each usage based on if it's needed for later git operations (e.g. git push)