### PR TITLE
patch: Add Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>canonical/data-platform//renovate_presets/preset_name.json5"],
+}


### PR DESCRIPTION
Update actions used in reusable workflows (e.g. actions/checkout)

Depends on https://github.com/canonical/data-platform/pull/41

Intentionally omit default `commitMessagePrefix` so that we check & classify (i.e. update PR title) whether update is backwards-compatible before merging