### PR TITLE
breaking(release_snap_*.yaml): Remove candid auth

### DIFF
--- a/.github/workflows/release_snap_edge.md
+++ b/.github/workflows/release_snap_edge.md
@@ -1,7 +1,7 @@
 Workflow file: [release_snap_edge.yaml](release_snap_edge.yaml)
 
 ## Usage
-Add `release.yaml` file to `.github/workflows/`
+### Step 1: Add `release.yaml` file to `.github/workflows/`
 ```yaml
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
@@ -39,9 +39,14 @@ jobs:
       contents: write  # Needed to create git tags
 ```
 
+### Step 2: Add Snap Store token
 Add `SNAP_STORE_TOKEN_EDGE` as an environment secret for the `edge` environment: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-environment. **Do not** add it as a repository secret.
 
-`SNAP_STORE_TOKEN_EDGE` should be generated with `SNAPCRAFT_STORE_AUTH=candid`—e.g.:
+`SNAP_STORE_TOKEN_EDGE` generation:
 ```
-SNAPCRAFT_STORE_AUTH=candid snapcraft export-login --snaps foo --channels latest/edge --expires 1970-01-01 -
+snapcraft export-login --snaps foo --channels latest/edge,foo/edge --expires 1970-01-01 -
 ```
+Replace:
+- `foo` with snap name
+- `latest` and `foo` with snap track(s)
+- `1970-01-01` with expiration date (that complies with https://library.canonical.com/corporate-policies/information-security-policies/secrets-management-policy)

--- a/.github/workflows/release_snap_edge.yaml
+++ b/.github/workflows/release_snap_edge.yaml
@@ -89,7 +89,6 @@ jobs:
         id: release
         run: release-snap-edge --directory="${VAR_DIRECTORY}" --track="${VAR_TRACK}"
         env:
-          SNAPCRAFT_STORE_AUTH: candid
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snap-store-token }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAR_DIRECTORY: ${{ inputs.path-to-snap-project-directory }}

--- a/.github/workflows/release_snap_pr.md
+++ b/.github/workflows/release_snap_pr.md
@@ -1,7 +1,7 @@
 Workflow file: [release_snap_pr.yaml](release_snap_pr.yaml)
 
 ## Usage
-Add `release.yaml` file to `.github/workflows/`
+### Step 1: Add `release.yaml` file to `.github/workflows/`
 ```yaml
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
@@ -31,9 +31,14 @@ jobs:
       contents: read
 ```
 
+### Step 2: Add Snap Store token
 Add `SNAP_STORE_TOKEN_EDGE_PR` as an environment secret for the `edge-pr` environment: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-environment. **Do not** add it as a repository secret.
 
-`SNAP_STORE_TOKEN_EDGE_PR` should be generated with `SNAPCRAFT_STORE_AUTH=candid`—e.g.:
+`SNAP_STORE_TOKEN_EDGE_PR` generation:
 ```
-SNAPCRAFT_STORE_AUTH=candid snapcraft export-login --snaps foo --channels latest/edge/pr-* --expires 1970-01-01 -
+snapcraft export-login --snaps foo --channels latest/edge/pr-*,foo/edge/pr-* --expires 1970-01-01 -
 ```
+Replace:
+- `foo` with snap name
+- `latest` and `foo` with snap track(s)
+- `1970-01-01` with expiration date (that complies with https://library.canonical.com/corporate-policies/information-security-policies/secrets-management-policy)

--- a/.github/workflows/release_snap_pr.yaml
+++ b/.github/workflows/release_snap_pr.yaml
@@ -84,7 +84,6 @@ jobs:
         id: release
         run: release-snap-pr --directory="${VAR_DIRECTORY}" --track="${VAR_TRACK}" --pr="${VAR_PR}"
         env:
-          SNAPCRAFT_STORE_AUTH: candid
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snap-store-token }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAR_DIRECTORY: ${{ inputs.path-to-snap-project-directory }}


### PR DESCRIPTION
Candid auth is being deprecated: https://discourse.canonical.com/t/charmhub-teams-deprecation/7035

Will remove candid auth from release_charm_*.yaml in a future PR when a non-candid auth is available in `charmcraft`

## Migration instructions
Remove Snap Store secret and follow usage docs for [release_snap_edge.yaml](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/release_snap_edge.md) or [release_snap_pr.yaml](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/release_snap_pr.md) to create new **environment** secret