### PR TITLE
compatible: Update upload-artifact

### DIFF
--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -161,7 +161,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-charm-directory }}'
       - name: Upload charm package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-${{ matrix.platform.name_in_artifact }}
           # .empty file required to preserve directory structure

--- a/.github/workflows/build_rock.yaml
+++ b/.github/workflows/build_rock.yaml
@@ -141,7 +141,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-rock-directory }}'
       - name: Upload rock package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-${{ matrix.platform.name }}
           # .empty file required to preserve directory structure

--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -146,7 +146,7 @@ jobs:
         id: path-in-artifact
         run: compute-path-in-artifact '${{ inputs.path-to-snap-project-directory }}'
       - name: Upload snap package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact-prefix }}-${{ steps.path-in-artifact.outputs.path }}--platform-${{ matrix.platform.name }}
           # .empty file required to preserve directory structure

--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -181,7 +181,7 @@ jobs:
         # Default test results in case the integration tests time out or runner set up fails
         # (So that Allure report will show "unknown"/"failed" test result, instead of omitting the test)
         if: ${{ inputs._beta_allure_report && github.event_name == 'schedule' && github.run_attempt == '1' }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           # TODO future improvement: ensure artifact name is unique (if called with a matrix that changes inputs)
           name: allure-collection-default-results-integration-test-charm
@@ -344,7 +344,7 @@ jobs:
         run: time curl -s -L -v -o charmed-postgresql_133.snap https://api.snapcraft.io/api/v1/snaps/download/mAiAP9VqaDs9TXjjb9RpIULHkYwb9IoH_133.snap > curl_debug.log 2>&1
       - name: Upload snap download logs for debugging
         timeout-minutes: 5
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: debug-logs-snap-download-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || steps.parse-versions.outputs.snap_channel_for_artifact }}-${{ inputs.architecture }}-${{ matrix.groups.artifact_group_id }}
           path: curl_debug.log
@@ -380,7 +380,7 @@ jobs:
       - name: Upload microk8s logs for debugging
         timeout-minutes: 5
         if: ${{ failure() && steps.microk8s-setup.outcome == 'failure' }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: debug-logs-microk8s-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || steps.parse-versions.outputs.snap_channel_for_artifact }}-${{ inputs.architecture }}-${{ matrix.groups.artifact_group_id }}
           path: /var/snap/microk8s/current/inspection-report-*.tar.gz
@@ -452,7 +452,7 @@ jobs:
       - name: (beta) Upload Allure results
         timeout-minutes: 3
         if: ${{ (success() || (failure() && steps.tests.outcome == 'failure')) && inputs._beta_allure_report && github.event_name == 'schedule' && github.run_attempt == '1' }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: allure-results-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || steps.parse-versions.outputs.snap_channel_for_artifact }}-${{ inputs.architecture }}-${{ matrix.groups.artifact_group_id }}
           path: allure-results/
@@ -472,7 +472,7 @@ jobs:
       - name: Upload logs
         timeout-minutes: 5
         if: ${{ success() || (failure() && steps.tests.outcome == 'failure') }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: logs-integration-test-charm-${{ inputs.cloud }}-juju-${{ inputs.juju-agent-version || steps.parse-versions.outputs.snap_channel_for_artifact }}-${{ inputs.architecture }}-${{ matrix.groups.artifact_group_id }}
           path: ~/logs/

--- a/.github/workflows/release_python_package_part1.yaml
+++ b/.github/workflows/release_python_package_part1.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Build package
         run: poetry build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions  # Keep in sync with `artifact-name` output
           path: dist/


### PR DESCRIPTION
This is to avoid warnings like `Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/upload-artifact@v5. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.`

<img width="1983" height="406" alt="image" src="https://github.com/user-attachments/assets/ccce618d-f1c3-424a-92e5-5f1d8a15919e" />
