### PR TITLE
patch(_promote_charm_legacy.yaml): Add path-to-charm input

### DIFF
--- a/.github/workflows/_promote_charm_legacy.yaml
+++ b/.github/workflows/_promote_charm_legacy.yaml
@@ -37,6 +37,10 @@ on:
           Cannot be used if `charmcraft-snap-revision` input is passed
         required: false
         type: string
+      path-to-charm-directory:
+        description: Relative path to charm directory from repository directory
+        default: .
+        type: string
     secrets:
       charmhub-token:
         description: Charmhub login token
@@ -83,7 +87,7 @@ jobs:
           fetch-depth: 0  # Checkout history with git tags
       - name: Promote charm
         id: promote
-        run: promote-charm-legacy --track="${VAR_TRACK}" --from-risk="${VAR_FROM_RISK}" --to-risk="${VAR_TO_RISK}" --ref="${VAR_REF}" --default-branch="${VAR_DEFAULT_BRANCH}"
+        run: promote-charm-legacy --track="${VAR_TRACK}" --from-risk="${VAR_FROM_RISK}" --to-risk="${VAR_TO_RISK}" --ref="${VAR_REF}" --directory="${VAR_DIRECTORY}" --default-branch="${VAR_DEFAULT_BRANCH}"
         env:
           CHARMCRAFT_AUTH: ${{ secrets.charmhub-token }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,6 +95,7 @@ jobs:
           VAR_FROM_RISK: ${{ inputs.from-risk }}
           VAR_TO_RISK: ${{ inputs.to-risk }}
           VAR_REF: ${{ github.ref }}
+          VAR_DIRECTORY: ${{ inputs.path-to-charm-directory }}
           VAR_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Charmcraft logs
         if: ${{ success() || (failure() && steps.promote.outcome == 'failure') }}

--- a/_cli/data_platform_workflows_cli/craft_tools/promote_legacy.py
+++ b/_cli/data_platform_workflows_cli/craft_tools/promote_legacy.py
@@ -161,12 +161,6 @@ def charm():
             f"{repr(from_risk.value)} to 'candidate' first"
         )
 
-    ref = args.ref
-    if not ref.startswith("refs/heads/"):
-        raise ValueError(
-            "This workflow must be run on `workflow_dispatch` from the branch that contains track "
-            f"{repr(track)}"
-        )
     default_branch = args.default_branch
 
     if not pathlib.Path(".github/release.yaml").exists():

--- a/_cli/data_platform_workflows_cli/craft_tools/promote_legacy.py
+++ b/_cli/data_platform_workflows_cli/craft_tools/promote_legacy.py
@@ -130,9 +130,10 @@ def charm():
     parser.add_argument("--from-risk", required=True)
     parser.add_argument("--to-risk", required=True)
     parser.add_argument("--ref", required=True)
+    parser.add_argument("--directory", required=True)
     parser.add_argument("--default-branch", required=True)
     args = parser.parse_args()
-    directory = pathlib.Path(".")
+    directory = pathlib.Path(args.directory)
 
     # Check if a refresh_versions.toml file exists anywhere in the repository
     if next(pathlib.Path().glob("**/refresh_versions.toml"), False):

--- a/_cli/data_platform_workflows_cli/craft_tools/promote_legacy.py
+++ b/_cli/data_platform_workflows_cli/craft_tools/promote_legacy.py
@@ -161,6 +161,12 @@ def charm():
             f"{repr(from_risk.value)} to 'candidate' first"
         )
 
+    ref = args.ref
+    if not ref.startswith("refs/heads/"):
+        raise ValueError(
+            "This workflow must be run on `workflow_dispatch` from the branch that contains track "
+            f"{repr(track)}"
+        )
     default_branch = args.default_branch
 
     if not pathlib.Path(".github/release.yaml").exists():


### PR DESCRIPTION
This PR updates the `_promote_charm_legacy` workflow in order to expose an **optional** path-to-charm-directory input.

Despite this workflow being _legacy_, it is the only shared workflow that allows the promotion of non refresh-v3 charms. As of now, this workflow has always being used in repositories with a single charm (placed at the root folder) but with the adoption of more complex mono-repo setups, it may be needed in repositories containing multiple charms.

This is the case of MySQL 8.0 mono-repo.

---

Tested by this [PR](https://github.com/canonical/mysql-operators/pull/241) in this [CI run](https://github.com/canonical/mysql-operators/actions/runs/24450786614).