### PR TITLE
patch(build_rock.yaml): Extend rock build timeout

### DIFF
--- a/.github/workflows/build_rock.yaml
+++ b/.github/workflows/build_rock.yaml
@@ -91,7 +91,7 @@ jobs:
     needs:
       - collect-platforms
     runs-on: ${{ matrix.platform.runner }}
-    timeout-minutes: 15
+    timeout-minutes: 60
     steps:
       - name: (IS hosted) Install pipx
         if: ${{ contains(matrix.platform.runner, 'self-hosted') }}


### PR DESCRIPTION
s390x rock builds are consistently hitting the 15 min timeout limit while still in base setup. An increased value should allow the source-heavy s390x builds to complete on the runners available. This is currently blocking artifact builds for an OpenStack s390x deployment.