### PR TITLE
breaking: Remove get-workflow-version-action

### DIFF
--- a/.github/workflows/__check_pr.yaml
+++ b/.github/workflows/__check_pr.yaml
@@ -14,5 +14,4 @@ jobs:
   check-pr:
     name: Check pull request
     uses: ./.github/workflows/check_python_package_pr.yaml
-    permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
+    permissions: {}

--- a/.github/workflows/_promote_charm_legacy_1.md
+++ b/.github/workflows/_promote_charm_legacy_1.md
@@ -46,7 +46,6 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to edit GitHub releases
 ```
 ### Step 2: Add `check_pr.yaml` file to `.github/workflows/`

--- a/.github/workflows/_promote_charm_legacy_1.yaml
+++ b/.github/workflows/_promote_charm_legacy_1.yaml
@@ -62,17 +62,10 @@ jobs:
         run: |
           # shellcheck disable=SC2016
           echo '::warning::The `_promote_charm_legacy_1.yaml` workflow is deprecated & will be removed in a future release.'
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: _promote_charm_legacy_1.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Parse charmcraft version inputs
         id: charmcraft-snap-version
         run: parse-snap-version --revision="${VAR_REVISION}" --channel="${VAR_CHANNEL}" --revision-input-name=charmcraft-snap-revision --channel-input-name=charmcraft-snap-channel
@@ -105,5 +98,4 @@ jobs:
         if: ${{ success() || (failure() && steps.promote.outcome == 'failure') }}
         run: cat ~/.local/state/charmcraft/log/*
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: write  # Needed to edit GitHub releases

--- a/.github/workflows/_promote_charms.md
+++ b/.github/workflows/_promote_charms.md
@@ -47,7 +47,6 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to edit GitHub releases
 ```
 

--- a/.github/workflows/_promote_charms.yaml
+++ b/.github/workflows/_promote_charms.yaml
@@ -54,17 +54,10 @@ jobs:
       name: ${{ inputs.to-risk }}
       deployment: true
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: _promote_charms.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Parse charmcraft version inputs
         id: charmcraft-snap-version
         run: parse-snap-version --revision="${VAR_REVISION}" --channel="${VAR_CHANNEL}" --revision-input-name=charmcraft-snap-revision --channel-input-name=charmcraft-snap-channel
@@ -96,5 +89,4 @@ jobs:
         if: ${{ success() || (failure() && steps.promote.outcome == 'failure') }}
         run: cat ~/.local/state/charmcraft/log/*
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: write  # Needed to edit GitHub releases

--- a/.github/workflows/_promote_charms_legacy_2.md
+++ b/.github/workflows/_promote_charms_legacy_2.md
@@ -48,7 +48,6 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to edit GitHub releases
 ```
 ### Step 2: Add `check_pr.yaml` file to `.github/workflows/`

--- a/.github/workflows/_promote_charms_legacy_2.yaml
+++ b/.github/workflows/_promote_charms_legacy_2.yaml
@@ -58,17 +58,10 @@ jobs:
         run: |
           # shellcheck disable=SC2016
           echo '::warning::The `_promote_charms_legacy_2.yaml` workflow is deprecated & will be removed in a future release.'
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: _promote_charms_legacy_2.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Parse charmcraft version inputs
         id: charmcraft-snap-version
         run: parse-snap-version --revision="${VAR_REVISION}" --channel="${VAR_CHANNEL}" --revision-input-name=charmcraft-snap-revision --channel-input-name=charmcraft-snap-channel
@@ -100,5 +93,4 @@ jobs:
         if: ${{ success() || (failure() && steps.promote.outcome == 'failure') }}
         run: cat ~/.local/state/charmcraft/log/*
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: write  # Needed to edit GitHub releases

--- a/.github/workflows/_update_bundle.md
+++ b/.github/workflows/_update_bundle.md
@@ -24,7 +24,6 @@ jobs:
     secrets:
       token: ${{ secrets.CREATE_PR_APP_TOKEN }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to push branch
       pull-requests: write  # Needed to create PR
 ```

--- a/.github/workflows/_update_bundle.yaml
+++ b/.github/workflows/_update_bundle.yaml
@@ -38,17 +38,10 @@ jobs:
       name: update-bundle
       deployment: false
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: _update_bundle.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -84,6 +77,5 @@ jobs:
           GH_TOKEN: ${{ secrets.token }}
           VAR_REVIEWERS: ${{ inputs.reviewers }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: write  # Needed to push branch
       pull-requests: write  # Needed to create PR

--- a/.github/workflows/build_charm.md
+++ b/.github/workflows/build_charm.md
@@ -9,7 +9,6 @@ jobs:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v0.0.0
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: read
 ```
 

--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -61,17 +61,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: build_charm.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -84,7 +77,6 @@ jobs:
     outputs:
       platforms: ${{ steps.collect.outputs.platforms }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: read
 
   build:
@@ -103,17 +95,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install pipx -y
           pipx ensurepath
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: build_charm.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Parse charmcraft version inputs
         id: charmcraft-snap-version
         run: parse-snap-version --revisions="${VAR_REVISIONS}" --channel="${VAR_CHANNEL}" --revision-input-name=charmcraft-snap-revisions --channel-input-name=charmcraft-snap-channel
@@ -199,5 +184,4 @@ jobs:
           include-hidden-files: true  # For `.empty`
           if-no-files-found: error
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: read

--- a/.github/workflows/build_rock.md
+++ b/.github/workflows/build_rock.md
@@ -9,7 +9,6 @@ jobs:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v0.0.0
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: read
 ```
 

--- a/.github/workflows/build_rock.yaml
+++ b/.github/workflows/build_rock.yaml
@@ -57,17 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: build_rock.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -80,7 +73,6 @@ jobs:
     outputs:
       platforms: ${{ steps.collect.outputs.platforms }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: read
 
   build:
@@ -99,17 +91,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install pipx -y
           pipx ensurepath
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: build_rock.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Parse rockcraft version inputs
         id: rockcraft-snap-version
         run: parse-snap-version --revisions="${VAR_REVISIONS}" --channel="${VAR_CHANNEL}" --revision-input-name=rockcraft-snap-revisions --channel-input-name=rockcraft-snap-channel
@@ -178,5 +163,4 @@ jobs:
           include-hidden-files: true  # For `.empty`
           if-no-files-found: error
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: read

--- a/.github/workflows/build_snap.md
+++ b/.github/workflows/build_snap.md
@@ -9,7 +9,6 @@ jobs:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v0.0.0
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: read
 ```
 

--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -60,17 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: build_snap.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -83,7 +76,6 @@ jobs:
     outputs:
       platforms: ${{ steps.collect.outputs.platforms }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: read
 
   build:
@@ -102,17 +94,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install pipx -y
           pipx ensurepath
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: build_snap.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Parse snapcraft version inputs
         id: snapcraft-snap-version
         run: parse-snap-version --revisions="${VAR_REVISIONS}" --channel="${VAR_CHANNEL}" --revision-input-name=snapcraft-snap-revisions --channel-input-name=snapcraft-snap-channel
@@ -182,5 +167,4 @@ jobs:
           include-hidden-files: true  # For `.empty`
           if-no-files-found: error
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: read

--- a/.github/workflows/check_python_package_pr.yaml
+++ b/.github/workflows/check_python_package_pr.yaml
@@ -7,21 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: check_python_package_pr.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Check pull request
         run: check-python-package-pr-title
         # Use env variable to avoid script injection
         env:
           TITLE: ${{ github.event.pull_request.title }}
-    permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+    permissions: {}

--- a/.github/workflows/release_charm_edge.md
+++ b/.github/workflows/release_charm_edge.md
@@ -21,7 +21,6 @@ jobs:
     with:
       track: 'latest'
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to create git tag
   
   build:
@@ -30,7 +29,6 @@ jobs:
       - tag
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v0.0.0
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: read
 
   release:
@@ -45,7 +43,6 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to create git tags
 ```
 

--- a/.github/workflows/release_charm_edge.yaml
+++ b/.github/workflows/release_charm_edge.yaml
@@ -52,17 +52,10 @@ jobs:
     outputs:
       charm-revisions: ${{ steps.release.outputs.charm-revisions }}
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: release_charm_edge.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Parse charmcraft version inputs
         id: charmcraft-snap-version
         run: parse-snap-version --revision="${VAR_REVISION}" --channel="${VAR_CHANNEL}" --revision-input-name=charmcraft-snap-revision --channel-input-name=charmcraft-snap-channel
@@ -119,5 +112,4 @@ jobs:
         if: ${{ success() || (failure() && steps.release.outcome == 'failure') }}
         run: cat ~/.local/state/charmcraft/log/*
     permissions:
-      actions: read # Needed for GitHub API call to get workflow version (for private repositories)
-      contents: write # Needed to create git tags
+      contents: write  # Needed to create git tags

--- a/.github/workflows/release_charm_pr.md
+++ b/.github/workflows/release_charm_pr.md
@@ -12,7 +12,6 @@ jobs:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v0.0.0
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: read
 
   release:
@@ -26,7 +25,6 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: read
 ```
 

--- a/.github/workflows/release_charm_pr.yaml
+++ b/.github/workflows/release_charm_pr.yaml
@@ -49,17 +49,10 @@ jobs:
     outputs:
       charm-revisions: ${{ steps.release.outputs.charm-revisions }}
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: release_charm_pr.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Parse charmcraft version inputs
         id: charmcraft-snap-version
         run: parse-snap-version --revision="${VAR_REVISION}" --channel="${VAR_CHANNEL}" --revision-input-name=charmcraft-snap-revision --channel-input-name=charmcraft-snap-channel
@@ -117,5 +110,4 @@ jobs:
         if: ${{ success() || (failure() && steps.release.outcome == 'failure') }}
         run: cat ~/.local/state/charmcraft/log/*
     permissions:
-      actions: read # Needed for GitHub API call to get workflow version (for private repositories)
       contents: read

--- a/.github/workflows/release_python_package.md
+++ b/.github/workflows/release_python_package.md
@@ -44,7 +44,6 @@ jobs:
     name: Release to PyPI (part 1)
     uses: canonical/data-platform-workflows/.github/workflows/release_python_package_part1.yaml@v0.0.0
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to create git tag
 
   # Separate job needed to workaround https://github.com/pypi/warehouse/issues/11096
@@ -98,8 +97,7 @@ jobs:
   check-pr:
     name: Check pull request
     uses: canonical/data-platform-workflows/.github/workflows/check_python_package_pr.yaml@v0.0.0
-    permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
+    permissions: {}
 ```
 
 ### Step 4: Configure GitHub repository settings

--- a/.github/workflows/release_python_package_part1.yaml
+++ b/.github/workflows/release_python_package_part1.yaml
@@ -14,17 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: release_python_package_part1.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -36,7 +29,6 @@ jobs:
     outputs:
       tag: ${{ steps.create-tag.outputs.tag }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: write  # Needed to create git tag
   
   build:

--- a/.github/workflows/release_rock_edge.md
+++ b/.github/workflows/release_rock_edge.md
@@ -21,7 +21,6 @@ jobs:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v0.0.0
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: read
 
   release:
@@ -32,7 +31,6 @@ jobs:
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       packages: write  # Needed to publish to GitHub Container Registry
       contents: write  # Needed to create git tags
 ```

--- a/.github/workflows/release_rock_edge.yaml
+++ b/.github/workflows/release_rock_edge.yaml
@@ -33,17 +33,10 @@ jobs:
     outputs:
       rock-digests: ${{ steps.release.outputs.rock-digests }}
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: release_rock_edge.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Install skopeo
         run: |
           sudo apt-get update
@@ -56,7 +49,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: unused # Required input—but not used
+          username: unused  # Required input—but not used
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Compute path in artifact
         id: path-in-artifact
@@ -75,6 +68,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VAR_DIRECTORY: ${{ inputs.path-to-rock-directory }}
     permissions:
-      actions: read # Needed for GitHub API call to get workflow version (for private repositories)
-      packages: write # Needed to publish to GitHub Container Registry
-      contents: write # Needed to create git tags
+      packages: write  # Needed to publish to GitHub Container Registry
+      contents: write  # Needed to create git tags

--- a/.github/workflows/release_snap_edge.md
+++ b/.github/workflows/release_snap_edge.md
@@ -21,7 +21,6 @@ jobs:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v0.0.0
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: read
 
   release:
@@ -35,7 +34,6 @@ jobs:
     secrets:
       snap-store-token: ${{ secrets.SNAP_STORE_TOKEN_EDGE }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to create git tags
 ```
 

--- a/.github/workflows/release_snap_edge.yaml
+++ b/.github/workflows/release_snap_edge.yaml
@@ -55,17 +55,10 @@ jobs:
     outputs:
       snap-revisions: ${{ steps.release.outputs.snap-revisions }}
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: release_snap_edge.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Parse snapcraft version inputs
         id: snapcraft-snap-version
         run: parse-snap-version --revision="${VAR_REVISION}" --channel="${VAR_CHANNEL}" --revision-input-name=snapcraft-snap-revision --channel-input-name=snapcraft-snap-channel
@@ -103,5 +96,4 @@ jobs:
         if: ${{ success() || (failure() && steps.release.outcome == 'failure') }}
         run: cat ~/.local/state/snapcraft/log/*
     permissions:
-      actions: read # Needed for GitHub API call to get workflow version (for private repositories)
-      contents: write # Needed to create git tags
+      contents: write  # Needed to create git tags

--- a/.github/workflows/release_snap_pr.md
+++ b/.github/workflows/release_snap_pr.md
@@ -13,7 +13,6 @@ jobs:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v0.0.0
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: read
 
   release:
@@ -27,7 +26,6 @@ jobs:
     secrets:
       snap-store-token: ${{ secrets.SNAP_STORE_TOKEN_EDGE_PR }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: read
 ```
 

--- a/.github/workflows/release_snap_pr.yaml
+++ b/.github/workflows/release_snap_pr.yaml
@@ -50,17 +50,10 @@ jobs:
     outputs:
       snap-revisions: ${{ steps.release.outputs.snap-revisions }}
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: release_snap_pr.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Parse snapcraft version inputs
         id: snapcraft-snap-version
         run: parse-snap-version --revision="${VAR_REVISION}" --channel="${VAR_CHANNEL}" --revision-input-name=snapcraft-snap-revision --channel-input-name=snapcraft-snap-channel
@@ -99,5 +92,4 @@ jobs:
         if: ${{ success() || (failure() && steps.release.outcome == 'failure') }}
         run: cat ~/.local/state/snapcraft/log/*
     permissions:
-      actions: read # Needed for GitHub API call to get workflow version (for private repositories)
       contents: read

--- a/.github/workflows/sync_docs.md
+++ b/.github/workflows/sync_docs.md
@@ -23,7 +23,6 @@ jobs:
     with:
       reviewers: canonical/data-platform-technical-authors,octocat
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to push branch & tag
       pull-requests: write  # Needed to create PR
 ```

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -16,17 +16,10 @@ jobs:
       run: |
         # shellcheck disable=SC2016
         echo '::warning::The `sync_docs.yaml` workflow is deprecated & will be removed in a future release.'
-    - name: Get workflow version
-      id: workflow-version
-      uses: canonical/get-workflow-version-action@v1
-      with:
-        repository-name: canonical/data-platform-workflows
-        file-name: sync_docs.yaml
-        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install CLI
       run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
       env:
-        VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+        VAR_SHA: ${{ job.workflow_sha }}
     - name: Checkout
       uses: actions/checkout@v6
       with:
@@ -66,6 +59,5 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         VAR_REVIEWERS: ${{ inputs.reviewers }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: write  # Needed to push branch & tag
       pull-requests: write  # Needed to create PR

--- a/.github/workflows/tag_charm_edge.yaml
+++ b/.github/workflows/tag_charm_edge.yaml
@@ -16,17 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Get workflow version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/data-platform-workflows
-          file-name: tag_charm_edge.yaml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
         env:
-          VAR_SHA: ${{ steps.workflow-version.outputs.sha }}
+          VAR_SHA: ${{ job.workflow_sha }}
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -37,5 +30,4 @@ jobs:
         env:
           VAR_TRACK: ${{ inputs.track }}
     permissions:
-      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: write  # Needed to create git tag


### PR DESCRIPTION
GitHub added `job.workflow_sha` (https://github.com/actions/runner/issues/2417#issuecomment-4307892505), removing the need for our workaround

## Migration instructions

Remove
```yaml
      actions: read  # Needed for GitHub API call to get workflow version
```
from `permissions` for all workflows.

If no permissions are left, use
```yaml
    permissions: {}
```