### PR TITLE
patch: Ignore actionlint false positive for `job.workflow_sha`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,4 +8,5 @@ self-hosted-runner:
 paths:
   .github/workflows/**/*.{yml,yaml}:
     ignore:
+      # TODO: Remove when https://github.com/rhysd/actionlint/issues/647 is fixed
       - 'property "workflow_sha" is not defined in object type'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,8 @@ self-hosted-runner:
     - xlarge
     - two-xlarge
     - jammy
+
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      - 'property "workflow_sha" is not defined in object type'


### PR DESCRIPTION
See rhysd/actionlint#647

(Edit to re-trigger pr check?)