### PR TITLE
compatible(_promote_snaps.yaml): Define new workflow

### DIFF
--- a/.github/workflows/_promote_snaps.md
+++ b/.github/workflows/_promote_snaps.md
@@ -1,0 +1,60 @@
+Workflow file: [_promote_snaps.yaml](_promote_snaps.yaml)
+
+> [!WARNING]
+> Subject to **breaking changes on patch release**. `_promote_snaps.yaml` is experimental & not part of the public interface.
+
+## Usage
+### Step 1: Add `promote.yaml` file to `.github/workflows/`
+```yaml
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Promote snaps
+
+on:
+  workflow_dispatch:
+    inputs:
+      from-risk:
+        description: Promote from this Snapcraft risk
+        required: true
+        type: choice
+        options:
+          - edge
+          - beta
+          - candidate
+      to-risk:
+        description: Promote to this Snapcraft risk
+        required: true
+        type: choice
+        options:
+          - beta
+          - candidate
+          - stable
+
+jobs:
+  promote:
+    name: Promote snaps
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_snaps.yaml@v0.0.0
+    with:
+      track: 'latest'
+      from-risk: ${{ inputs.from-risk }}
+      to-risk: ${{ inputs.to-risk }}
+    secrets:
+      snapcraft-token: ${{ secrets.SNAPCRAFT_TOKEN }}
+    permissions:
+      contents: write  # Needed to edit GitHub releases
+```
+
+### Step 2: Add `.github/release.yaml` file
+```yaml
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+```
+
+### Step 3: Ensure snapcraft.yaml file is present
+This workflow requires the snap directory to contain a snapcraft.yaml file with the `name` key.

--- a/.github/workflows/_promote_snaps.yaml
+++ b/.github/workflows/_promote_snaps.yaml
@@ -1,0 +1,79 @@
+on:
+  workflow_call:
+    inputs:
+      track:
+        description: Snapcraft track
+        required: true
+        type: string
+      from-risk:
+        description: Promote from `track` input and this Snapcraft risk. Must be one of "edge", "beta", "candidate"
+        required: true
+        type: string
+      to-risk:
+        description: Promote to `track` input and this Snapcraft risk. Must be one of "beta", "candidate", "stable"
+        required: true
+        type: string
+      snapcraft-snap-revision:
+        description: Snapcraft snap revision
+        required: false
+        type: string
+      snapcraft-snap-channel:
+        description: Snapcraft snap channel. Cannot be used if `snapcraft-snap-revision` input is passed
+        required: false
+        type: string
+      path-to-snap-directory:
+        description: Relative path to snap directory from repository directory
+        default: .
+        type: string
+    secrets:
+      snap-store-token:
+        description: Snap Store login token
+        required: true
+
+jobs:
+  promote-snap:
+    name: Promote snaps from ${{ inputs.track }}/${{ inputs.from-risk }} to ${{ inputs.track }}/${{ inputs.to-risk }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: ${{ inputs.to-risk }}
+      deployment: true
+    steps:
+      - name: Install CLI
+        run: pipx install git+https://github.com/canonical/data-platform-workflows@"${VAR_SHA}"#subdirectory=_cli
+        env:
+          VAR_SHA: ${{ job.workflow_sha }}
+      - name: Parse snapcraft version inputs
+        id: parse-snapcraft-version
+        run: parse-snap-version --revision="${VAR_REVISION}" --channel="${VAR_CHANNEL}" --revision-input-name=snapcraft-snap-revision --channel-input-name=snapcraft-snap-channel
+        env:
+          VAR_REVISION: ${{ inputs.snapcraft-snap-revision }}
+          VAR_CHANNEL: ${{ inputs.snapcraft-snap-channel }}
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic ${VAR_INSTALL_FLAG:+"${VAR_INSTALL_FLAG}"}
+        env:
+          VAR_INSTALL_FLAG: ${{ steps.parse-snapcraft-version.outputs.install_flag }}
+      - name: List the installed snaps
+        run: snap list
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0  # Checkout history with git tags
+      - name: Promote snaps
+        id: promote-snaps
+        run: promote-snaps --track="${VAR_TRACK}" --from-risk="${VAR_FROM_RISK}" --to-risk="${VAR_TO_RISK}" --ref="${VAR_REF}" --directory="${VAR_DIRECTORY}" --default-branch="${VAR_DEFAULT_BRANCH}"
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snap-store-token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VAR_TRACK: ${{ inputs.track }}
+          VAR_FROM_RISK: ${{ inputs.from-risk }}
+          VAR_TO_RISK: ${{ inputs.to-risk }}
+          VAR_REF: ${{ github.ref }}
+          VAR_DIRECTORY: ${{ inputs.path-to-snap-directory }}
+          VAR_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      - name: Snapcraft logs
+        if: ${{ success() || (failure() && steps.promote-snaps.outcome == 'failure') }}
+        run: cat ~/.local/state/snapcraft/log/*
+    permissions:
+      contents: write  # Needed to edit GitHub releases

--- a/_cli/data_platform_workflows_cli/craft_tools/promote_snaps.py
+++ b/_cli/data_platform_workflows_cli/craft_tools/promote_snaps.py
@@ -124,11 +124,12 @@ def snaps():
         )
 
     ref = args.ref
-    if not ref.startswith("refs/heads/"):
-        raise ValueError(
-            "This workflow must be run on `workflow_dispatch` from the branch that contains track "
-            f"{repr(track)}"
-        )
+    # Remove safety precaution just to validate it on CI.
+    # if not ref.startswith("refs/heads/"):
+    #     raise ValueError(
+    #         "This workflow must be run on `workflow_dispatch` from the branch that contains track "
+    #         f"{repr(track)}"
+    #     )
 
     if not pathlib.Path(".github/release.yaml").exists():
         raise FileNotFoundError(

--- a/_cli/data_platform_workflows_cli/craft_tools/promote_snaps.py
+++ b/_cli/data_platform_workflows_cli/craft_tools/promote_snaps.py
@@ -1,0 +1,233 @@
+import argparse
+import enum
+import logging
+import pathlib
+import subprocess
+import sys
+
+import requests
+import yaml
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+
+
+class Direction(enum.StrEnum):
+    FROM = "from"
+    TO = "to"
+
+
+class Risk(enum.StrEnum):
+    """Snapcraft risk"""
+
+    # In order from lowest to highest risk
+    STABLE = "stable"
+    CANDIDATE = "candidate"
+    BETA = "beta"
+    EDGE = "edge"
+
+    @classmethod
+    def get(cls, value, *, direction: Direction):  # Cannot override __call__ or __new__
+        valid_risks = [risk.value for risk in cls]
+        if direction is Direction.FROM:
+            valid_risks.remove(Risk.STABLE.value)
+        elif direction is Direction.TO:
+            valid_risks.remove(Risk.EDGE.value)
+        else:
+            raise TypeError
+        if value not in valid_risks:
+            raise ValueError(
+                f"`{direction.value}-risk` input must be one of {repr(valid_risks)}. "
+                f"Got: {repr(value)}"
+            )
+        return cls(value)
+
+
+def get_snap_revisions(channel_name: str, snap_name: str, tag_prefix: str, raise_missing: bool):
+    """Get the current snap revisions in the target channel."""
+    logging.info(f"Getting revisions on {repr(channel_name)}")
+    response = requests.get(
+        f"https://api.snapcraft.io/v2/snaps/info/{snap_name}",
+        headers={"Snap-Device-Series": "16"},
+        params={"fields": "revision"},
+    )
+
+    response.raise_for_status()
+    channels = response.json()["channel-map"]
+    revisions = []
+    for channel in channels:
+        if channel["channel"]["name"] == channel_name:
+            revisions.append(channel["revision"])
+
+    if not revisions and raise_missing:
+        raise ValueError(f"No revisions exist on {repr(channel_name)}")
+
+    logging.info(f"Revisions on {repr(channel_name)}: {repr(revisions)}")
+    logging.info("Checking that revisions were built from the same git commit")
+    commit_shas = set()
+
+    for revision in revisions:
+        tag = f"{tag_prefix}{revision}"
+        try:
+            process = subprocess.run(
+                ["git", "rev-list", "-n", "1", tag],
+                capture_output=True,
+                check=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError:
+            logging.error(f"Unable to find git tag {repr(tag)}.")
+            raise
+        else:
+            commit_shas.add(process.stdout.strip())
+
+    if len(commit_shas) != 1:
+        raise ValueError(
+            f"Revisions {repr(revisions)} were built from different commits: {repr(commit_shas)}. "
+            "Revisions must be built from the same git commit to correctly apply git tags for risk"
+        )
+
+    commit_sha = commit_shas.pop()
+    logging.info(f"All revisions on {repr(channel_name)} were built from commit {repr(commit_sha)}")
+    return commit_sha, revisions
+
+
+def snaps():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--track", required=True)
+    parser.add_argument("--from-risk", required=True)
+    parser.add_argument("--to-risk", required=True)
+    parser.add_argument("--ref", required=True)
+    parser.add_argument("--directory", required=True)
+    parser.add_argument("--default-branch", required=True)
+    args = parser.parse_args()
+
+    directory = pathlib.Path(args.directory)
+    default_branch = args.default_branch
+
+    track = args.track
+    if track == "":
+        raise ValueError("`track` input must not be empty string")
+    if "/" in track:
+        raise ValueError("`track` input cannot contain '/' character")
+
+    from_risk = Risk.get(args.from_risk, direction=Direction.FROM)
+    to_risk = Risk.get(args.to_risk, direction=Direction.TO)
+    if not to_risk < from_risk:
+        raise ValueError(
+            f"`to-risk` input ({repr(to_risk.value)}) must be lower risk than "
+            f"`from-risk` input ({repr(from_risk.value)})"
+        )
+    if to_risk is Risk.STABLE and from_risk is not Risk.CANDIDATE:
+        raise ValueError(
+            "Only the 'candidate' risk can be promoted to 'stable'. "
+            f"Promote {repr(from_risk.value)} to 'candidate' first"
+        )
+
+    ref = args.ref
+    if not ref.startswith("refs/heads/"):
+        raise ValueError(
+            "This workflow must be run on `workflow_dispatch` from the branch that contains track "
+            f"{repr(track)}"
+        )
+
+    if not pathlib.Path(".github/release.yaml").exists():
+        raise FileNotFoundError(
+            "Repository must contain `.github/release.yaml` to automatically generate "
+            "release notes in the correct format. "
+            "See https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/_promote_snaps.md"
+        )
+
+    from_channel = f"{track}/{from_risk}"
+    to_channel = f"{track}/{to_risk}"
+
+    current_snap_metadata = yaml.safe_load((directory / "snapcraft.yaml").read_text())
+    current_snap_name = current_snap_metadata["name"]
+
+    if directory in (pathlib.Path("."), pathlib.Path("snap")):
+        tag_prefix = "rev"
+    else:
+        tag_prefix = f"{current_snap_name}/rev"
+
+    logging.info("Checking that revisions that will be promoted are from the same commit")
+    commit_sha, _ = get_snap_revisions(from_channel, current_snap_name, tag_prefix, True)
+
+    subprocess.run(["git", "checkout", commit_sha], check=True)
+
+    commit_snap_metadata = yaml.safe_load((directory / "snapcraft.yaml").read_text())
+    commit_snap_name = commit_snap_metadata["name"]
+    if commit_snap_name != current_snap_name:
+        raise ValueError(
+            "Snap name in snapcraft.yaml changed between latest commit on branch "
+            f"({current_snap_name}) and commit on {from_channel} "
+            f"({commit_snap_name}). Unable to promote charm"
+        )
+
+    subprocess.run(["git", "checkout", "-"], check=True)
+
+    logging.info(f"Promoting {current_snap_name} snap")
+    subprocess.run(
+        [
+            "snapcraft",
+            "promote",
+            current_snap_name,
+            f"--from-channel={from_channel}",
+            f"--to-channel={to_channel}",
+            "--yes",
+        ],
+        check=True,
+    )
+
+    logging.info("Getting the revisions that were promoted")
+    _, promoted_revisions = get_snap_revisions(to_channel, current_snap_name, tag_prefix, True)
+
+    # Pick alphabetically first tag because of
+    # https://github.com/orgs/community/discussions/149281#discussioncomment-12071170
+    promoted_possible_release_tags = [f"{tag_prefix}{revision}" for revision in promoted_revisions]
+    promoted_github_release_tag = sorted(promoted_possible_release_tags)[0]
+
+    if to_risk is Risk.CANDIDATE:
+        stable_channel = f"{track}/{Risk.STABLE.value}"
+
+        logging.info(f"Getting the revisions for the {stable_channel} release")
+        _, stable_revisions = get_snap_revisions(stable_channel, current_snap_name, tag_prefix, False)
+        if not stable_revisions:
+            logging.warning(f"No existing release found on {stable_channel}")
+            stable_github_release_tag = None
+        else:
+            # Pick alphabetically first tag because of
+            # https://github.com/orgs/community/discussions/149281#discussioncomment-12071170
+            stable_possible_release_tags = [f"{tag_prefix}{revision}" for revision in stable_revisions]
+            stable_github_release_tag = sorted(stable_possible_release_tags)[0]
+
+        title = f"Revisions {', '.join(str(revision) for revision in sorted(promoted_revisions))}"
+        notes = f"Revision for the {current_snap_name} snap have been published to the {stable_channel} channel"
+        command = [
+            "gh",
+            "release",
+            "create",
+            promoted_github_release_tag,
+            "--verify-tag",
+            "--generate-notes",
+            "--draft=true",
+            "--latest=false",
+            f"--title={title}",
+            f"--notes={notes}",
+        ]
+        if stable_github_release_tag is not None:
+            command.extend(("--notes-start-tag", stable_github_release_tag))
+        logging.info("Creating GitHub draft release")
+        subprocess.run(command, check=True)
+
+    elif to_risk is Risk.STABLE:
+        command = [
+            "gh",
+            "release",
+            "edit",
+            promoted_github_release_tag,
+            "--verify-tag",
+            "--draft=false",
+        ]
+        if ref != f"refs/heads/{default_branch}":
+            command.append("--latest=false")
+        logging.info("Creating GitHub release")
+        subprocess.run(command, check=True)

--- a/_cli/data_platform_workflows_cli/craft_tools/promote_snaps.py
+++ b/_cli/data_platform_workflows_cli/craft_tools/promote_snaps.py
@@ -124,12 +124,11 @@ def snaps():
         )
 
     ref = args.ref
-    # Remove safety precaution just to validate it on CI.
-    # if not ref.startswith("refs/heads/"):
-    #     raise ValueError(
-    #         "This workflow must be run on `workflow_dispatch` from the branch that contains track "
-    #         f"{repr(track)}"
-    #     )
+    if not ref.startswith("refs/heads/"):
+        raise ValueError(
+            "This workflow must be run on `workflow_dispatch` from the branch that contains track "
+            f"{repr(track)}"
+        )
 
     if not pathlib.Path(".github/release.yaml").exists():
         raise FileNotFoundError(

--- a/_cli/pyproject.toml
+++ b/_cli/pyproject.toml
@@ -29,6 +29,7 @@ compute-path-in-artifact = "data_platform_workflows_cli.compute_path_in_artifact
 promote-charms = "data_platform_workflows_cli.craft_tools.promote:charms"
 promote-charm-legacy-1 = "data_platform_workflows_cli.craft_tools.promote_legacy_1:charm"
 promote-charms-legacy-2 = "data_platform_workflows_cli.craft_tools.promote_legacy_2:charms"
+promote-snaps = "data_platform_workflows_cli.craft_tools.promote_snaps:snaps"
 check-python-package-pr-title = "data_platform_workflows_cli.check_semantic_version_prefix:check_pr_title"
 create-semantic-version-tag = "data_platform_workflows_cli.create_semantic_version_tag:main"
 create-charm-version-tag-edge = "data_platform_workflows_cli.create_charm_refresh_version_tag_edge:main"


### PR DESCRIPTION
This PR defines a new **experimental** `_promote_snaps` workflow in order to standardize how we can promote snap revisions from a particular risk to the next. It follows the same logic as one of the charm promotion workflows, using the same structure and safety precautions (i.e. all revisions must come from the same commit).

### Usage requirements
- To have a `.github/release.yaml` file, stating which PR labels are going to be considered for release notes.
- To create tags called `revXYZ` in single-snap repos and `<snap-name>/revXYZ` in multi-snap repos.
- To have a Snapcraft store token that allows publication into the target risk.

### Testing

In order to test it, I commented out the requirement to have the workflow triggered by a `workflow-dispatch` event. Then, I proposed draft PRs on a couple of repos and saw their `/edge` revisions being promoted to `/beta`.

- Single-snap repo: charmed-mysql-snap (see [draft PR](https://github.com/canonical/charmed-mysql-snap/pull/115) + [CI run](https://github.com/canonical/charmed-mysql-snap/actions/runs/29578623450/job/87882829687?pr=115)).
- Multi-snap repo: valkey-artifacts (see [draft PR](https://github.com/canonical/valkey-artifacts/pull/11) + [CI run](https://github.com/canonical/valkey-artifacts/actions/runs/29754097064/job/88391879594)).

---

Related to JIRA ticket [DPE-10694](https://warthogs.atlassian.net/browse/DPE-10694).

[DPE-10694]: https://warthogs.atlassian.net/browse/DPE-10694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ