### PR TITLE
breaking(release_charm_*.yaml): Remove candid auth

### DIFF
--- a/.github/workflows/_promote_charm_legacy_1.md
+++ b/.github/workflows/_promote_charm_legacy_1.md
@@ -44,7 +44,7 @@ jobs:
       from-risk: ${{ inputs.from-risk }}
       to-risk: ${{ inputs.to-risk }}
     secrets:
-      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN_PROMOTION }}
     permissions:
       contents: write  # Needed to edit GitHub releases
 ```
@@ -84,7 +84,24 @@ changelog:
         - bug
 ```
 
-### Step 4: Ensure metadata.yaml file is present
+### Step 4: Require approval for `stable` environment
+Add the relevant team (e.g. canonical/data-postgresql) as a required reviewer before a workflow run with access to the `stable` GitHub environment can start: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-required-reviews-in-workflows. This prevents an attacker who has compromised our workflows (e.g. via a supply chain attack) from (immediately) compromising our stable release artifacts.
+
+### Step 5: Add Charmhub tokens
+Add `CHARMHUB_TOKEN_PROMOTION` as an environment secret for the `beta` environment: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-environment. **Do not** add it as a repository secret.
+
+`CHARMHUB_TOKEN_PROMOTION` generation (requires charmcraft >=4.4.0):
+```
+charmcraft login --quiet --charm foo --channel latest/beta --channel bar/beta --ttl 3600 --permission package-manage-releases --permission package-view-releases --export /dev/stdout
+```
+Replace:
+- `foo` with charm name
+- `latest` and `bar` with charm track(s)
+- `3600` with expiration in seconds (that complies with https://library.canonical.com/corporate-policies/information-security-policies/secrets-management-policy)
+
+Repeat the above steps, replacing `beta` with `candidate` in both the charmcraft command and in the GitHub environment name. Repeat again with `stable`. In total, generate 3 separate tokens.
+
+### Step 6: Ensure metadata.yaml file is present
 This workflow requires the charm directory (directory with charmcraft.yaml) to contain a metadata.yaml file with the `name` and `display-name` keys. For Kubernetes charms, all `oci-image` `resources` must be pinned to a sha256 digest. Syntax: https://juju.is/docs/sdk/metadata-yaml
 
 "Unified charmcraft.yaml syntax" (where actions.yaml, charmcraft.yaml, config.yaml, and metadata.yaml are combined into a single charmcraft.yaml file) is not supported.

--- a/.github/workflows/_promote_charm_legacy_1.md
+++ b/.github/workflows/_promote_charm_legacy_1.md
@@ -85,7 +85,7 @@ changelog:
 ```
 
 ### Step 4: Require approval for `stable` environment
-Add the relevant team (e.g. canonical/data-postgresql) as a required reviewer before a workflow run with access to the `stable` GitHub environment can start: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-required-reviews-in-workflows. This prevents an attacker who has compromised our workflows (e.g. via a supply chain attack) from (immediately) compromising our stable release artifacts.
+Add the relevant team (e.g. canonical/data-postgresql) as a required reviewer before a job with access to the `stable` GitHub environment can start: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-required-reviews-in-workflows. This prevents an attacker who has compromised our workflows (e.g. via a supply chain attack) from (immediately) compromising our stable release artifacts.
 
 ### Step 5: Add Charmhub tokens
 Add `CHARMHUB_TOKEN_PROMOTION` as an environment secret for the `beta` environment: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-environment. **Do not** add it as a repository secret.

--- a/.github/workflows/_promote_charm_legacy_1.yaml
+++ b/.github/workflows/_promote_charm_legacy_1.yaml
@@ -51,9 +51,6 @@ jobs:
     name: (deprecated) Promote charm from ${{ inputs.track }}/${{ inputs.from-risk }} to ${{ inputs.track }}/${{ inputs.to-risk }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # TODO future improvement: when https://bugs.launchpad.net/snapstore-server/+bug/2097446 is
-    # fixed, use isolated per-environment secrets for different risks & require manual approval to
-    # access stable secret in order to improve security posture & avoid mistakes
     environment:
       name: ${{ inputs.to-risk }}
       deployment: true

--- a/.github/workflows/_promote_charms.md
+++ b/.github/workflows/_promote_charms.md
@@ -86,7 +86,7 @@ changelog:
 ```
 
 ### Step 4: Require approval for `stable` environment
-Add the relevant team (e.g. canonical/data-postgresql) as a required reviewer before a workflow run with access to the `stable` GitHub environment can start: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-required-reviews-in-workflows. This prevents an attacker who has compromised our workflows (e.g. via a supply chain attack) from (immediately) compromising our stable release artifacts.
+Add the relevant team (e.g. canonical/data-postgresql) as a required reviewer before a job with access to the `stable` GitHub environment can start: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-required-reviews-in-workflows. This prevents an attacker who has compromised our workflows (e.g. via a supply chain attack) from (immediately) compromising our stable release artifacts.
 
 ### Step 5: Add Charmhub tokens
 Add `CHARMHUB_TOKEN_PROMOTION` as an environment secret for the `beta` environment: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-environment. **Do not** add it as a repository secret.

--- a/.github/workflows/_promote_charms.md
+++ b/.github/workflows/_promote_charms.md
@@ -93,7 +93,7 @@ Add `CHARMHUB_TOKEN_PROMOTION` as an environment secret for the `beta` environme
 
 `CHARMHUB_TOKEN_PROMOTION` generation (requires charmcraft >=4.4.0):
 ```
-charmcraft login --quiet --charm foo --channel latest/beta --channel bar/beta --ttl 3600 --permission package-manage-releases --export /dev/stdout
+charmcraft login --quiet --charm foo --channel latest/beta --channel bar/beta --ttl 3600 --permission package-manage-releases --permission package-manage-revisions --permission package-view-revisions --export /dev/stdout
 ```
 Replace:
 - `foo` with charm name

--- a/.github/workflows/_promote_charms.md
+++ b/.github/workflows/_promote_charms.md
@@ -45,7 +45,7 @@ jobs:
       track: 'latest'
       to-risk: ${{ inputs.to-risk }}
     secrets:
-      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN_PROMOTION }}
     permissions:
       contents: write  # Needed to edit GitHub releases
 ```
@@ -85,7 +85,24 @@ changelog:
         - bug
 ```
 
-### Step 4: Ensure metadata.yaml file is present
+### Step 4: Require approval for `stable` environment
+Add the relevant team (e.g. canonical/data-postgresql) as a required reviewer before a workflow run with access to the `stable` GitHub environment can start: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-required-reviews-in-workflows. This prevents an attacker who has compromised our workflows (e.g. via a supply chain attack) from (immediately) compromising our stable release artifacts.
+
+### Step 5: Add Charmhub tokens
+Add `CHARMHUB_TOKEN_PROMOTION` as an environment secret for the `beta` environment: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-environment. **Do not** add it as a repository secret.
+
+`CHARMHUB_TOKEN_PROMOTION` generation (requires charmcraft >=4.4.0):
+```
+charmcraft login --quiet --charm foo --channel latest/beta --channel bar/beta --ttl 3600 --permission package-manage-releases --export /dev/stdout
+```
+Replace:
+- `foo` with charm name
+- `latest` and `bar` with charm track(s)
+- `3600` with expiration in seconds (that complies with https://library.canonical.com/corporate-policies/information-security-policies/secrets-management-policy)
+
+Repeat the above steps, replacing `beta` with `candidate` in both the charmcraft command and in the GitHub environment name. Repeat again with `stable`. In total, generate 3 separate tokens.
+
+### Step 6: Ensure metadata.yaml file is present
 This workflow requires the charm directory (directory with charmcraft.yaml) to contain a metadata.yaml file with the `name` and `display-name` keys. For Kubernetes charms, all `oci-image` `resources` must be pinned to a sha256 digest. Syntax: https://juju.is/docs/sdk/metadata-yaml
 
 "Unified charmcraft.yaml syntax" (where actions.yaml, charmcraft.yaml, config.yaml, and metadata.yaml are combined into a single charmcraft.yaml file) is not supported.

--- a/.github/workflows/_promote_charms.yaml
+++ b/.github/workflows/_promote_charms.yaml
@@ -47,9 +47,6 @@ jobs:
     name: Promote charms (revisions ${{ inputs.revisions }}) to ${{ inputs.track }}/${{ inputs.to-risk }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # TODO future improvement: when https://bugs.launchpad.net/snapstore-server/+bug/2097446 is
-    # fixed, use isolated per-environment secrets for different risks & require manual approval to
-    # access stable secret in order to improve security posture & avoid mistakes
     environment:
       name: ${{ inputs.to-risk }}
       deployment: true

--- a/.github/workflows/_promote_charms_legacy_2.md
+++ b/.github/workflows/_promote_charms_legacy_2.md
@@ -85,7 +85,7 @@ changelog:
         - bug
 ```
 ### Step 4: Require approval for `stable` environment
-Add the relevant team (e.g. canonical/data-postgresql) as a required reviewer before a workflow run with access to the `stable` GitHub environment can start: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-required-reviews-in-workflows. This prevents an attacker who has compromised our workflows (e.g. via a supply chain attack) from (immediately) compromising our stable release artifacts.
+Add the relevant team (e.g. canonical/data-postgresql) as a required reviewer before a job with access to the `stable` GitHub environment can start: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-required-reviews-in-workflows. This prevents an attacker who has compromised our workflows (e.g. via a supply chain attack) from (immediately) compromising our stable release artifacts.
 
 ### Step 5: Add Charmhub tokens
 Add `CHARMHUB_TOKEN_PROMOTION` as an environment secret for the `beta` environment: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-environment. **Do not** add it as a repository secret.

--- a/.github/workflows/_promote_charms_legacy_2.md
+++ b/.github/workflows/_promote_charms_legacy_2.md
@@ -46,7 +46,7 @@ jobs:
       from-risk: ${{ inputs.from-risk }}
       to-risk: ${{ inputs.to-risk }}
     secrets:
-      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN_PROMOTION }}
     permissions:
       contents: write  # Needed to edit GitHub releases
 ```
@@ -84,8 +84,24 @@ changelog:
       labels:
         - bug
 ```
+### Step 4: Require approval for `stable` environment
+Add the relevant team (e.g. canonical/data-postgresql) as a required reviewer before a workflow run with access to the `stable` GitHub environment can start: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-required-reviews-in-workflows. This prevents an attacker who has compromised our workflows (e.g. via a supply chain attack) from (immediately) compromising our stable release artifacts.
 
-### Step 4: Ensure metadata.yaml file is present
+### Step 5: Add Charmhub tokens
+Add `CHARMHUB_TOKEN_PROMOTION` as an environment secret for the `beta` environment: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-environment. **Do not** add it as a repository secret.
+
+`CHARMHUB_TOKEN_PROMOTION` generation (requires charmcraft >=4.4.0):
+```
+charmcraft login --quiet --charm foo --channel latest/beta --channel bar/beta --ttl 3600 --permission package-manage-releases --permission package-view-releases --export /dev/stdout
+```
+Replace:
+- `foo` with charm name
+- `latest` and `bar` with charm track(s)
+- `3600` with expiration in seconds (that complies with https://library.canonical.com/corporate-policies/information-security-policies/secrets-management-policy)
+
+Repeat the above steps, replacing `beta` with `candidate` in both the charmcraft command and in the GitHub environment name. Repeat again with `stable`. In total, generate 3 separate tokens.
+
+### Step 6: Ensure metadata.yaml file is present
 This workflow requires the charm directory (directory with charmcraft.yaml) to contain a metadata.yaml file with the `name` and `display-name` keys. For Kubernetes charms, all `oci-image` `resources` must be pinned to a sha256 digest. Syntax: https://juju.is/docs/sdk/metadata-yaml
 
 "Unified charmcraft.yaml syntax" (where actions.yaml, charmcraft.yaml, config.yaml, and metadata.yaml are combined into a single charmcraft.yaml file) is not supported.

--- a/.github/workflows/_promote_charms_legacy_2.yaml
+++ b/.github/workflows/_promote_charms_legacy_2.yaml
@@ -47,9 +47,6 @@ jobs:
     name: (deprecated) Promote charms from ${{ inputs.track }}/${{ inputs.from-risk }} to ${{ inputs.track }}/${{ inputs.to-risk }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # TODO future improvement: when https://bugs.launchpad.net/snapstore-server/+bug/2097446 is
-    # fixed, use isolated per-environment secrets for different risks & require manual approval to
-    # access stable secret in order to improve security posture & avoid mistakes
     environment:
       name: ${{ inputs.to-risk }}
       deployment: true

--- a/.github/workflows/release_charm_edge.md
+++ b/.github/workflows/release_charm_edge.md
@@ -1,7 +1,7 @@
 Workflow file: [release_charm_edge.yaml](release_charm_edge.yaml)
 
 ## Usage
-Add `release.yaml` file to `.github/workflows/`
+### Step 1: Add `release.yaml` file to `.github/workflows/`
 
 For charms that do not implement in-place upgrades & rollbacks with [charm-refresh](https://github.com/canonical/charm-refresh), the `tag` job should be omitted.
 ```yaml
@@ -41,12 +41,24 @@ jobs:
       track: ${{ needs.tag.outputs.track }}
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     secrets:
-      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN_EDGE }}
     permissions:
       contents: write  # Needed to create git tags
 ```
 
-### metadata.yaml required
+### Step 2: Add Charmhub token
+Add `CHARMHUB_TOKEN_EDGE` as an environment secret for the `edge` environment: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-environment. **Do not** add it as a repository secret.
+
+`CHARMHUB_TOKEN_EDGE` generation (requires charmcraft >=4.4.0):
+```
+charmcraft login --quiet --charm foo --channel latest/edge --channel bar/edge --ttl 3600 --permission package-manage-releases --permission package-manage-revisions --permission package-view-revisions --export /dev/stdout
+```
+Replace:
+- `foo` with charm name
+- `latest` and `bar` with charm track(s)
+- `3600` with expiration in seconds (that complies with https://library.canonical.com/corporate-policies/information-security-policies/secrets-management-policy)
+
+### Step 3: Ensure metadata.yaml file is present
 This workflow requires the charm directory (directory with charmcraft.yaml) to contain a metadata.yaml file with the `name` key. If the charm uses OCI images (Kubernetes only), metadata.yaml must also contain the `resources` key. Syntax: https://juju.is/docs/sdk/metadata-yaml
 
 "Unified charmcraft.yaml syntax" (where actions.yaml, charmcraft.yaml, config.yaml, and metadata.yaml are combined into a single charmcraft.yaml file) is not supported.

--- a/.github/workflows/release_charm_edge.yaml
+++ b/.github/workflows/release_charm_edge.yaml
@@ -44,8 +44,6 @@ jobs:
     name: Release charm to ${{ inputs.track }}/edge
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # TODO future improvement: when https://bugs.launchpad.net/snapstore-server/+bug/2097446 is
-    # fixed, use isolated per-environment secrets for different risks
     environment:
       name: edge
       deployment: true

--- a/.github/workflows/release_charm_pr.md
+++ b/.github/workflows/release_charm_pr.md
@@ -1,6 +1,7 @@
 Workflow file: [release_charm_pr.yaml](release_charm_pr.yaml)
 
 ## Usage
+### Step 1: Add `.yaml` file to `.github/workflows/`
 ```yaml
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
@@ -23,12 +24,24 @@ jobs:
       track: 'latest'
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     secrets:
-      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN_EDGE_PR }}
     permissions:
       contents: read
 ```
 
-### metadata.yaml required
+### Step 2: Add Charmhub token
+Add `CHARMHUB_TOKEN_EDGE_PR` as an environment secret for the `edge-pr` environment: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-environment. **Do not** add it as a repository secret.
+
+`CHARMHUB_TOKEN_EDGE_PR` generation (requires charmcraft >=4.4.0):
+```
+charmcraft login --quiet --charm foo --channel latest/edge/pr-* --channel bar/edge/pr-* --ttl 3600 --permission package-manage-releases --permission package-manage-revisions --permission package-view-revisions --export /dev/stdout
+```
+Replace:
+- `foo` with charm name
+- `latest` and `bar` with charm track(s)
+- `3600` with expiration in seconds (that complies with https://library.canonical.com/corporate-policies/information-security-policies/secrets-management-policy)
+
+### Step 3: Ensure metadata.yaml file is present
 This workflow requires the charm directory (directory with charmcraft.yaml) to contain a metadata.yaml file with the `name` key. If the charm uses OCI images (Kubernetes only), metadata.yaml must also contain the `resources` key. Syntax: https://juju.is/docs/sdk/metadata-yaml
 
 "Unified charmcraft.yaml syntax" (where actions.yaml, charmcraft.yaml, config.yaml, and metadata.yaml are combined into a single charmcraft.yaml file) is not supported.

--- a/.github/workflows/release_charm_pr.yaml
+++ b/.github/workflows/release_charm_pr.yaml
@@ -41,8 +41,6 @@ jobs:
     name: Release charm to ${{ inputs.track }}/edge/pr-${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # TODO future improvement: when https://bugs.launchpad.net/snapstore-server/+bug/2097446 is
-    # fixed, use isolated per-environment secrets for different risks
     environment:
       name: edge-pr
       deployment: false

--- a/.github/workflows/release_snap_edge.md
+++ b/.github/workflows/release_snap_edge.md
@@ -42,9 +42,9 @@ Add `SNAP_STORE_TOKEN_EDGE` as an environment secret for the `edge` environment:
 
 `SNAP_STORE_TOKEN_EDGE` generation:
 ```
-snapcraft export-login --snaps foo --channels latest/edge,foo/edge --expires 1970-01-01 -
+snapcraft export-login --snaps foo --channels latest/edge,bar/edge --expires 1970-01-01 -
 ```
 Replace:
 - `foo` with snap name
-- `latest` and `foo` with snap track(s)
+- `latest` and `bar` with snap track(s)
 - `1970-01-01` with expiration date (that complies with https://library.canonical.com/corporate-policies/information-security-policies/secrets-management-policy)

--- a/.github/workflows/release_snap_pr.md
+++ b/.github/workflows/release_snap_pr.md
@@ -1,7 +1,7 @@
 Workflow file: [release_snap_pr.yaml](release_snap_pr.yaml)
 
 ## Usage
-### Step 1: Add `release.yaml` file to `.github/workflows/`
+### Step 1: Add `.yaml` file to `.github/workflows/`
 ```yaml
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
@@ -34,9 +34,9 @@ Add `SNAP_STORE_TOKEN_EDGE_PR` as an environment secret for the `edge-pr` enviro
 
 `SNAP_STORE_TOKEN_EDGE_PR` generation:
 ```
-snapcraft export-login --snaps foo --channels latest/edge/pr-*,foo/edge/pr-* --expires 1970-01-01 -
+snapcraft export-login --snaps foo --channels latest/edge/pr-*,bar/edge/pr-* --expires 1970-01-01 -
 ```
 Replace:
 - `foo` with snap name
-- `latest` and `foo` with snap track(s)
+- `latest` and `bar` with snap track(s)
 - `1970-01-01` with expiration date (that complies with https://library.canonical.com/corporate-policies/information-security-policies/secrets-management-policy)


### PR DESCRIPTION
charmcraft 4.4.0 removes support for Candid auth in favor of Ubuntu One auth: https://github.com/canonical/charmcraft/pull/2760

- Update docs to include token generation instructions
- Use newly supported channel glob to reduce token scope for release_charm_pr.yaml (independent of Candid deprecation): https://bugs.launchpad.net/snapstore-server/+bug/2097446
- Use environment-scoped secrets to improve security posture per https://discourse.canonical.com/t/security-update-action-requested/7120. We held off in https://github.com/canonical/data-platform-workflows/pull/347 for charms until the Candid migration to avoid requiring secret rotation to happen twice

## Migration instructions
### release_charm_edge.yaml
Remove `CHARMHUB_TOKEN` secret and follow [usage docs](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/release_charm_edge.md) to create new **environment** secret. Update secret name in workflow call.

### release_charm_pr.yaml
Remove `CHARMHUB_TOKEN` secret and follow [usage docs](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/release_charm_pr.md) to create new **environment** secret. Update secret name in workflow call.

### _promote_charms.yaml
Remove `CHARMHUB_TOKEN` secret and follow [usage docs](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/_promote_charms.md) to create new **environment** secret. Update secret name in workflow call.

### _promote_charms_legacy_2.yaml
Remove `CHARMHUB_TOKEN` secret and follow [usage docs](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/_promote_charms_legacy_2.md) to create new **environment** secret. Update secret name in workflow call.

### _promote_charm_legacy_1.yaml
Remove `CHARMHUB_TOKEN` secret and follow [usage docs](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/_promote_charm_legacy_1.md) to create new **environment** secret. Update secret name in workflow call.