### PR TITLE
patch(_promote_snaps.yaml): Fix risk comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 | [_promote_charms.yaml](.github/workflows/_promote_charms.md)                   | **Experimental** Promote charms by revision & generate release notes                                              |
 | [_promote_charm_legacy_1.yaml](.github/workflows/_promote_charm_legacy_1.md)   | **Deprecated** `charmcraft promote` & generate release notes for charm without refresh compatibility version tags |
 | [_promote_charms_legacy_2.yaml](.github/workflows/_promote_charms_legacy_2.md) | **Deprecated** `charmcraft promote` & generate release notes                                                      |
+| [_promote_snaps.yaml](.github/workflows/_promote_snaps.md)                     | **Experimental** `snapcraft promote` & generate release notes                                                     |
 | [check_charm_pr.yaml](.github/workflows/check_charm_pr.md)                     | Check charm pull request has required labels for release notes                                                    |
 | [approve_renovate_pr.yaml](.github/workflows/approve_renovate_pr.md)           | Reduce required approvals on [Renovate](https://docs.renovatebot.com/) pull requests by 1                         |
 | [_update_bundle.yaml](.github/workflows/_update_bundle.md)                     | **Experimental** Update charm revisions in bundle                                                                 |
@@ -71,4 +72,3 @@ Workflows that begin with two underscores (e.g. `__foo.yaml`) are for this repos
 
 Data Platform Workflows is covered by the [Ubuntu Code of
 Conduct](https://ubuntu.com/community/ethos/code-of-conduct).
-

--- a/_cli/data_platform_workflows_cli/craft_tools/promote_snaps.py
+++ b/_cli/data_platform_workflows_cli/craft_tools/promote_snaps.py
@@ -41,6 +41,12 @@ class Risk(enum.StrEnum):
             )
         return cls(value)
 
+    def __lt__(self, other):
+        if not isinstance(other, Risk):
+            raise TypeError
+        order = list(Risk)
+        return order.index(self) < order.index(other)
+
 
 def get_snap_revisions(channel_name: str, snap_name: str, tag_prefix: str, raise_missing: bool):
     """Get the current snap revisions in the target channel."""


### PR DESCRIPTION
This PR is a follow-up to the one where the `_promote_snaps.yaml` workflow was introduced, where the comparison between risks is fixed (see failed [CI run](https://github.com/canonical/mysql-snap/actions/runs/30101358409)).