### PR TITLE
patch: add bld support in snap builds

### DIFF
--- a/.github/workflows/build_snap.yaml
+++ b/.github/workflows/build_snap.yaml
@@ -20,7 +20,7 @@ on:
       snapcraft-snap-revisions:
         description: |
           JSON string with type dict[str, str] of architecture to snapcraft snap revision
-          
+
           Example: `{"amd64": "16585", "arm64": "16587"}`
         required: false
         type: string
@@ -54,6 +54,17 @@ on:
           Timeout in minutes for the build job
         default: 30
         type: number
+      sd-build:
+        description: |
+          Install the tools for SD build.
+        default: false
+        type: boolean
+      craft_sd_env:
+        description: |
+          the env to use to pull artifacts from
+          This is only used if `sd-build` is true.
+        default: production
+        type: string
     outputs:
       artifact-prefix:
         description: Snap packages are uploaded to GitHub artifacts beginning with this prefix
@@ -87,7 +98,7 @@ jobs:
     strategy:
       matrix:
         platform: ${{ fromJSON(needs.collect-platforms.outputs.platforms) }}
-    name: 'Build snap | ${{ matrix.platform.name }}'
+    name: "Build snap | ${{ matrix.platform.name }}"
     needs:
       - collect-platforms
     runs-on: ${{ matrix.platform.runner }}
@@ -140,6 +151,11 @@ jobs:
         env:
           VAR_LXD_FLAG: ${{ steps.lxd-snap-version.outputs.install_flag }}
           VAR_SNAPCRAFT_FLAG: ${{ steps.snapcraft-snap-version.outputs.install_flag }}
+      - name: Set up SD build environment
+        if: ${{ inputs.sd-build }}
+        run: |
+          sudo snap install craft-sd --channel=latest/beta
+          sudo snap install bld --edge
       - run: snap list
       - name: Pack snap
         id: pack
@@ -148,6 +164,8 @@ jobs:
         env:
           SNAPCRAFT_BUILD_INFO: 1
           VAR_PLATFORM: ${{ matrix.platform.name }}
+          CI: ${{ inputs.sd-build && 1 || '' }}
+          CRAFT_SD_ENV: ${{ inputs.sd-build && inputs.craft_sd_env || '' }}
       - name: Snapcraft logs
         if: ${{ success() || (failure() && steps.pack.outcome == 'failure') }}
         run: cat ~/.local/state/snapcraft/log/*
@@ -169,7 +187,7 @@ jobs:
           path: |
             ${{ inputs.path-to-snap-project-directory }}/*.snap
             .empty
-          include-hidden-files: true  # For `.empty`
+          include-hidden-files: true # For `.empty`
           if-no-files-found: error
     permissions:
       contents: read


### PR DESCRIPTION
Adds optional sd build support to the `build_snap.yaml` reusable workflow. When enabled, the workflow installs `craft-sd` and `bld` and exposes the `CI` / `CRAFT_SD_ENV` environment variables to the snapcraft pack step so artifacts can be pulled from the correct environment.

## Context
- This support is opt-in via a new `sd-build` input (default `false`), so existing consumers of the workflow are unaffected.

## Changes

- **New inputs** in `.github/workflows/build_snap.yaml`:
  - `sd-build` (boolean, default `false`) — installs the required build tools (`craft-sd` from `latest/beta`, `bld` from `edge`) when `true`.
  - `craft_sd_env` (string, default `production`) — the environment to pull artifacts from. Only used when `sd-build` is `true`.
- **New step** `Set up sd build environment` (gated on `inputs.sd-build`) that installs the `craft-sd` and `bld` snaps.
- **Pack step env** now sets:
  - `CI` to `1` when `sd-build` is enabled (empty otherwise) (hack to make arm builds work as well).
  - `CRAFT_SD_ENV` to `inputs.craft_sd_env` when `sd-build` is enabled (empty otherwise).
- Minor whitespace/quote style cleanups in the same file (trailing-space removal, single→double quotes for the matrix job name, comment alignment).

## Backward compatibility

Fully backward compatible: the new inputs default to `false` / `production`, so workflows that do not set `sd-build` behave exactly as before — no SD tools are installed and no extra env vars are passed to snapcraft.

## Testing
Tested [here](https://github.com/canonical/valkey-artifacts/actions/runs/31362723090/job/93374756969).